### PR TITLE
Prevent editing historical/archival schedules (IETFDB 3166)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Local to this project
 #################################################
 data/
+.factoryboy_random_state
+ietf/settings_local.py
+latest-coverage.json
+tmp-nomcom-public-keys-dir/
 
 
 

--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -358,7 +358,7 @@ def schedule_permissions(meeting, schedule, user):
 
     if user_is_person(user, schedule.owner):
         cansee = True
-        canedit = True
+        canedit = not schedule.is_official_record
 
     return cansee, canedit, secretariat
 

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -684,6 +684,11 @@ class Schedule(models.Model):
     def is_official(self):
         return (self.meeting.schedule == self)
 
+    @property
+    def is_official_record(self):
+        return (self.is_official and
+                self.meeting.end_date() <= datetime.date.today() )
+
     # returns a dictionary {group -> [schedtimesessassignment+]}
     # and it has [] if the session is not placed.
     # if there is more than one session for that group,

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1221,7 +1221,55 @@ class EditTests(TestCase):
         self.client.login(username="secretary", password="secretary+password")
         r = self.client.get(urlreverse("ietf.meeting.views.edit_schedule", kwargs=dict(num=meeting.number)))
         self.assertContains(r, "load_assignments")
- 
+
+    def test_official_record_schedule_is_read_only(self):
+        def _set_date_offset_and_retrieve_page(meeting, days_offset, client):
+            meeting.date = datetime.date.today() + datetime.timedelta(days=days_offset)
+            meeting.save()
+            client.login(username="secretary", password="secretary+password")
+            url = urlreverse("ietf.meeting.views.edit_meeting_schedule", kwargs=dict(num=meeting.number)) 
+            r = client.get(url)
+            q = PyQuery(r.content)
+            return(r, q)
+
+        # Setup
+        ####################################################################################
+
+        # Basic test data
+        meeting = make_meeting_test_data()
+
+        # Set the secretary as the owner of the schedule
+        schedule = meeting.schedule
+        schedule.owner = Person.objects.get(user__username="secretary")
+        schedule.save()
+
+        # Tests
+        ####################################################################################
+
+        # 1) Check that we get told the page is not editable
+        #######################################################
+        r, q = _set_date_offset_and_retrieve_page(meeting,
+                                                  0 - 2 - meeting.days, # Meeting ended 2 days ago
+                                                  self.client)
+        self.assertTrue(q("em:contains(\"You can't edit this schedule\")"))
+        self.assertTrue(q("em:contains(\"This is the official schedule for a meeting in the past\")"))
+
+        # 2) An ongoing meeting
+        #######################################################
+        r, q = _set_date_offset_and_retrieve_page(meeting,
+                                                  0, # Meeting starts today
+                                                  self.client)
+        self.assertFalse(q("em:contains(\"You can't edit this schedule\")"))
+        self.assertFalse(q("em:contains(\"This is the official schedule for a meeting in the past\")"))
+
+        # 3) A meeting in the future
+        #######################################################
+        r, q = _set_date_offset_and_retrieve_page(meeting,
+                                                  7, # Meeting starts next week
+                                                  self.client)
+        self.assertFalse(q("em:contains(\"You can't edit this schedule\")"))
+        self.assertFalse(q("em:contains(\"This is the official schedule for a meeting in the past\")"))
+
     def test_edit_meeting_schedule(self):
         meeting = make_meeting_test_data()
 

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1251,24 +1251,24 @@ class EditTests(TestCase):
         r, q = _set_date_offset_and_retrieve_page(meeting,
                                                   0 - 2 - meeting.days, # Meeting ended 2 days ago
                                                   self.client)
-        self.assertTrue(q("em:contains(\"You can't edit this schedule\")"))
-        self.assertTrue(q("em:contains(\"This is the official schedule for a meeting in the past\")"))
+        self.assertTrue(q("""eem:contains("You can't edit this schedule")"""))
+        self.assertTrue(q("""em:contains("This is the official schedule for a meeting in the past")"""))
 
         # 2) An ongoing meeting
         #######################################################
         r, q = _set_date_offset_and_retrieve_page(meeting,
                                                   0, # Meeting starts today
                                                   self.client)
-        self.assertFalse(q("em:contains(\"You can't edit this schedule\")"))
-        self.assertFalse(q("em:contains(\"This is the official schedule for a meeting in the past\")"))
+        self.assertFalse(q("""em:contains("You can't edit this schedule")"""))
+        self.assertFalse(q("""em:contains("This is the official schedule for a meeting in the past")"""))
 
         # 3) A meeting in the future
         #######################################################
         r, q = _set_date_offset_and_retrieve_page(meeting,
                                                   7, # Meeting starts next week
                                                   self.client)
-        self.assertFalse(q("em:contains(\"You can't edit this schedule\")"))
-        self.assertFalse(q("em:contains(\"This is the official schedule for a meeting in the past\")"))
+        self.assertFalse(q("""em:contains("You can't edit this schedule")"""))
+        self.assertFalse(q("""em:contains("This is the official schedule for a meeting in the past")"""))
 
     def test_edit_meeting_schedule(self):
         meeting = make_meeting_test_data()

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -46,7 +46,13 @@
       {% if not can_edit %}
         &middot;
 
-        <strong><em>You can't edit this schedule. Make a <a href="{% url "ietf.meeting.views.new_meeting_schedule" num=meeting.number owner=schedule.owner_email name=schedule.name %}">new agenda from this</a>.</em></strong>
+      <strong>
+        <em>
+          You can't edit this schedule.
+          {% if schedule.is_official_record %}This is the official schedule for a meeting in the past.{% endif %}
+          Make a <a href="{% url "ietf.meeting.views.new_meeting_schedule" num=meeting.number owner=schedule.owner_email name=schedule.name %}">new agenda from this</a>.
+        </em>
+      </strong>
       {% endif %}
     </p>
 

--- a/ietf/templates/meeting/landscape_edit.html
+++ b/ietf/templates/meeting/landscape_edit.html
@@ -107,6 +107,9 @@ promiselist.push(ss_promise);
   {% origin %}
 <div id="read_only">
   <p>You do not have write permission to agenda: {{schedule.name}}</p>
+  {% if schedule.is_official_record %}
+  <p>This is the official schedule for a meeting in the past.</p>
+  {% endif %}
   <p>Please save this agenda to your account first.</p>
 </div>
 


### PR DESCRIPTION
Note:  Oops, this should have been named "tix[3166](https://trac.tools.ietf.org/tools/ietfdb/ticket/3166)".

The datatracker has a graphical, drag-and-drop interface for scheduling sessions in a meeting.  (http://localhost:8080/meetings/NNN/agenda/edit) Nothing prevents the owner of the schedule from updating the schedule after the meeting has occurred, which causes database inconsistencies.  This is bad, and we should stop that.

This change updates the `schedule_permissions()` method in `ietf/meetings/helpers.py` to consider this in the calculation of permissions.  It adds a model method to assist in this, so that the model method can also be called in the views to decide whether to show a more specific message about the denied permissions.

Tests are added to boot.