### PR TITLE
Handle groups without an area when sorting unscheduled sessions in schedule editor

### DIFF
--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -385,11 +385,13 @@ jQuery(document).ready(function () {
         }
 
         function extractName(e) {
-            return e.querySelector(".session-label").innerHTML;
+            let labelElement = e.querySelector(".session-label");
+            return labelElement ? labelElement.innerHTML : '';
         }
 
         function extractParent(e) {
-            return e.querySelector(".session-parent").innerHTML;
+            let parentElement = e.querySelector(".session-parent");
+            return parentElement ? parentElement.innerHTML : '';
         }
 
         function extractDuration(e) {
@@ -400,15 +402,13 @@ jQuery(document).ready(function () {
             return e.querySelector(".session-info .comments") ? 0 : 1;
         }
 
-        let keyFunctions = [];
-        if (sortBy == "name")
-            keyFunctions = [extractName, extractDuration, extractId];
-        else if (sortBy == "parent")
-            keyFunctions = [extractParent, extractName, extractDuration, extractId];
-        else if (sortBy == "duration")
-            keyFunctions = [extractDuration, extractParent, extractName, extractId];
-        else if (sortBy == "comments")
-            keyFunctions = [extractComments, extractParent, extractName, extractDuration, extractId];
+        const keyFunctionMap = {
+            name: [extractName, extractDuration, extractId],
+            parent: [extractParent, extractName, extractDuration, extractId],
+            duration: [extractDuration, extractParent, extractName, extractId],
+            comments: [extractComments, extractParent, extractName, extractDuration, extractId]
+        };
+        let keyFunctions = keyFunctionMap[sortBy];
 
         let unassignedSessionsContainer = content.find(".unassigned-sessions .drop-target");
 


### PR DESCRIPTION
Fixes [ticket 3173](https://trac.ietf.org/trac/ietfdb/ticket/3173)

The bug occurred when a group that has no area was unscheduled. All of the sort methods except for by-name include by-parent as a sort criterion. The method that extracts the parent group acronym failed for groups that have no parent.

This fixes the bug by returning an empty string when there is no parent group. It also handles a similar potential bug when extracting the session name, although this cannot currently occur.

  * Cope with nulls from querySelector() in name and parent extractor methods
  * Minor code cleanup
  * Add a test to check session sorting