### PR TITLE
Remove authors as action holders after posting a new submission

### DIFF
--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -26,7 +26,7 @@ from ietf.doc.models import NewRevisionDocEvent
 from ietf.doc.models import RelatedDocument, DocRelationshipName, DocExtResource
 from ietf.doc.utils import add_state_change_event, rebuild_reference_relations
 from ietf.doc.utils import ( set_replaces_for_document, prettify_std_name,
-    update_doc_extresources, can_edit_docextresources, update_documentauthors )
+    update_doc_extresources, can_edit_docextresources, update_documentauthors, update_action_holders )
 from ietf.doc.mails import send_review_possibly_replaces_request, send_external_resource_change_request
 from ietf.group.models import Group
 from ietf.ietfauth.utils import has_role
@@ -372,6 +372,8 @@ def post_submission(request, submission, approved_doc_desc, approved_subm_desc):
     state_change_msg = ""
 
     if not was_rfc and draft.tags.filter(slug="need-rev"):
+        tags_before = list(draft.tags.all())
+
         draft.tags.remove("need-rev")
         if draft.stream_id == 'ietf':
             draft.tags.add("ad-f-up")
@@ -384,8 +386,12 @@ def post_submission(request, submission, approved_doc_desc, approved_subm_desc):
         e.by = system
         e.save()
         events.append(e)
-
         state_change_msg = e.desc
+
+        # Changed tags - update action holders if necessary
+        e = update_action_holders(draft, prev_tags=tags_before, new_tags=draft.tags.all())
+        if e is not None:
+            events.append(e)
 
     if draft.stream_id == "ietf" and draft.group.type_id == "wg" and draft.rev == "00":
         # automatically set state "WG Document"


### PR DESCRIPTION
This addresses [ticket 3281](https://trac.ietf.org/trac/ietfdb/ticket/3281), which reported that authors were not being removed as "action holders" when they submitted an updated draft. This left the impression that they still needed to do something to move the submission along.

This adds a call to `update_action_holders()` in a missed spot in the `post_submission()` method. This was missed in the original action holders implementation because the document IESG state is not actually changed, only the tags. However, the sub-state "needs ID revision" is encoded as a tag rather than a state, so a check is needed.

The change itself is pretty trivial; the test needed more work than the patch.