### PR TITLE
Display session and timeslot conflicts more prominently

### DIFF
--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1129,7 +1129,7 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 }
 
 .edit-meeting-schedule .edit-grid .timeslot.overfull {
-  border-right: 2px dashed #fff; /* cut-off illusion */
+  border-right: 0.3em dashed #f55000; /* cut-off illusion */
 }
 
 .edit-meeting-schedule .edit-grid .timeslot.would-violate-hint {

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1177,6 +1177,9 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   background-color: #f3f3f3;
 }
 
+.edit-meeting-schedule .session.would-violate-hint {
+    outline: 0.3em solid #F55000;
+}
 .edit-meeting-schedule .session.highlight .session-label {
   font-weight: bold;
 }

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1080,6 +1080,11 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
     align-items: center;
 }
 
+.edit-meeting-schedule .edit-grid .time-header .time-label.would-violate-hint {
+    background-color: #ffe0e0;
+    outline: #ffe0e0 solid 0.4em;
+}
+
 .edit-meeting-schedule .edit-grid .time-header .time-label span {
     display: inline-block;
     width: 100%;
@@ -1129,6 +1134,7 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 
 .edit-meeting-schedule .edit-grid .timeslot.would-violate-hint {
   background-color: #ffe0e0;
+  outline: #ffe0e0 solid 0.4em;
 }
 
 .edit-meeting-schedule .constraints .encircled,
@@ -1179,7 +1185,9 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 
 .edit-meeting-schedule .session.would-violate-hint {
     outline: 0.3em solid #F55000;
+    z-index: 1; /* raise up so the outline is not overdrawn */
 }
+
 .edit-meeting-schedule .session.highlight .session-label {
   font-weight: bold;
 }

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function () {
 
     let sessions = content.find(".session").not(".readonly");
     let timeslots = content.find(".timeslot");
+    let timeslotLabels = content.find(".time-label");
     let days = content.find(".day-flow .day");
 
     // hack to work around lack of position sticky support in old browsers, see https://caniuse.com/#feat=css-sticky
@@ -81,6 +82,39 @@ jQuery(document).ready(function () {
         constraintElt.toggleClass('would-violate-hint', wouldViolate);  // and the specific constraint
     }
 
+    /**
+     * Mark or unmark a timeslot that conflicts with the selected session
+     *
+     * If wholeInterval is true, marks the entire column in addition to the timeslot.
+     * This currently works by setting the class for the timeslot and the time-label
+     * in its column. Because this is called for every timeslot in the interval, the
+     * overall effect is to highlight the entire column.
+     *
+     * @param timeslotElt Timeslot element to be marked/unmarked
+     * @param wouldViolate True to mark or false to unmark
+     * @param wholeInterval Should the entire time interval be flagged or just the timeslot?
+     */
+    function setTimeslotWouldViolate(timeslotElt, wouldViolate, wholeInterval) {
+        timeslotElt = jQuery(timeslotElt);
+        timeslotElt.toggleClass('would-violate-hint', wouldViolate);
+        if (wholeInterval) {
+            let index = timeslotElt.index(); // position of this timeslot relative to its container
+            let label = timeslotElt
+                          .closest('div.room-group')
+                          .find('div.time-header .time-label')
+                          .get(index); // get time-label corresponding to this timeslot
+            jQuery(label).toggleClass('would-violate-hint', wouldViolate);
+        }
+    }
+
+    /**
+     * Remove all would-violate-hint classes on timeslots
+     */
+    function resetTimeslotsWouldViolate() {
+        timeslots.removeClass("would-violate-hint");
+        timeslotLabels.removeClass("would-violate-hint");
+    }
+
     function showConstraintHints(selectedSession) {
         let sessionId = selectedSession ? selectedSession.id.slice("session".length) : null;
         // hints on the sessions
@@ -102,7 +136,7 @@ jQuery(document).ready(function () {
         });
 
         // hints on timeslots
-        timeslots.removeClass("would-violate-hint");
+        resetTimeslotsWouldViolate();
         if (selectedSession) {
             let intervals = [];
             timeslots.filter(":has(.session .constraints > span.would-violate-hint)").each(function () {
@@ -110,15 +144,17 @@ jQuery(document).ready(function () {
             });
 
             let overlappingTimeslots = findTimeslotsOverlapping(intervals);
-            for (let i = 0; i < overlappingTimeslots.length; ++i)
-                overlappingTimeslots[i].addClass("would-violate-hint");
+            for (let i = 0; i < overlappingTimeslots.length; ++i) {
+                setTimeslotWouldViolate(overlappingTimeslots[i], true, true);
+            }
 
             // check room sizes
             let attendees = +selectedSession.dataset.attendees;
             if (attendees) {
                 timeslots.not(".would-violate-hint").each(function () {
-                    if (attendees > +jQuery(this).closest(".timeslots").data("roomcapacity"))
-                        jQuery(this).addClass("would-violate-hint");
+                    if (attendees > +jQuery(this).closest(".timeslots").data("roomcapacity")) {
+                        setTimeslotWouldViolate(this, true, false);
+                    }
                 });
             }
         }

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -68,21 +68,37 @@ jQuery(document).ready(function () {
         }
     }
 
+    /**
+     * Mark or unmark a session that conflicts with the selected session
+     *
+     * @param constraintElt The element corresponding to the specific constraint
+     * @param wouldViolate True to mark or false to unmark
+     */
+    function setSessionWouldViolate(constraintElt, wouldViolate) {
+        constraintElt = jQuery(constraintElt);
+        let constraintDiv = constraintElt.closest('div.session');  // find enclosing session div
+        constraintDiv.toggleClass('would-violate-hint', wouldViolate);  // mark the session container
+        constraintElt.toggleClass('would-violate-hint', wouldViolate);  // and the specific constraint
+    }
+
     function showConstraintHints(selectedSession) {
         let sessionId = selectedSession ? selectedSession.id.slice("session".length) : null;
         // hints on the sessions
         sessions.find(".constraints > span").each(function () {
-            if (!sessionId) {
-                jQuery(this).removeClass("would-violate-hint");
-                return;
+            let wouldViolate = false;
+            let applyChange = true;
+            if (sessionId) {
+                let sessionIds = this.dataset.sessions;
+                if (!sessionIds) {
+                    applyChange = False;
+                } else {
+                    wouldViolate = sessionIds.split(",").indexOf(sessionId) !== -1;
+                }
             }
 
-            let sessionIds = this.dataset.sessions;
-            if (!sessionIds)
-                return;
-
-            let wouldViolate = sessionIds.split(",").indexOf(sessionId) != -1;
-            jQuery(this).toggleClass("would-violate-hint", wouldViolate);
+            if (applyChange) {
+                setSessionWouldViolate(this, wouldViolate);
+            }
         });
 
         // hints on timeslots


### PR DESCRIPTION
This addresses [ticket 3221](https://trac.ietf.org/trac/ietfdb/ticket/3221)

The aim here is to:
1. Put a red outline around any sessions that have a conflict with the currently selected session
2. Extend the pink background of conflicting timeslots to be visible even when slots are full
3. Add pink background to the timeslot labels

There's a bit of javascript fun to identify the correct elements to label, otherwise just CSS.

(I was threatening to combine this with several other issues, but it's more complex than I remembered.)