### PR TITLE
Visually mark sessions belonging to same group as currently selected session

### DIFF
--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -228,9 +228,21 @@ class EditMeetingScheduleTests(IetfSeleniumTestCase):
         # hide sessions in area
         self.assertTrue(s1_element.is_displayed())
         self.driver.find_element_by_css_selector(".session-parent-toggles [value=\"{}\"]".format(s1.group.parent.acronym)).click()
-        self.assertTrue(not s1_element.is_displayed())
+        self.assertTrue(s1_element.is_displayed())  # should still be displayed
+        self.assertIn('hidden-parent', s1_element.get_attribute('class'),
+                      'Session should be hidden when parent disabled')
+        s1_element.click()  # try to select
+        self.assertNotIn('selected', s1_element.get_attribute('class'),
+                         'Session should not be selectable when parent disabled')
+
         self.driver.find_element_by_css_selector(".session-parent-toggles [value=\"{}\"]".format(s1.group.parent.acronym)).click()
         self.assertTrue(s1_element.is_displayed())
+        self.assertNotIn('hidden-parent', s1_element.get_attribute('class'),
+                         'Session should not be hidden when parent enabled')
+        s1_element.click()  # try to select
+        self.assertIn('selected', s1_element.get_attribute('class'),
+                         'Session should be selectable when parent enabled')
+
 
         # hide timeslots
         self.driver.find_element_by_css_selector(".timeslot-group-toggles button").click()

--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -108,8 +108,15 @@ class EditMeetingScheduleTests(IetfSeleniumTestCase):
 
         # select - show session info
         s2_element = self.driver.find_element_by_css_selector('#session{}'.format(s2.pk))
+        s2b_element = self.driver.find_element_by_css_selector('#session{}'.format(s2b.pk))
+        self.assertNotIn('other-session-selected', s2b_element.get_attribute('class'))
         s2_element.click()
 
+        # other session for group should be flagged for highlighting
+        s2b_element = self.driver.find_element_by_css_selector('#session{}'.format(s2b.pk))
+        self.assertIn('other-session-selected', s2b_element.get_attribute('class'))
+
+        # other session for group should appear in the info panel
         session_info_container = self.driver.find_element_by_css_selector('.session-info-container')
         self.assertIn(s2.group.acronym, session_info_container.find_element_by_css_selector(".title").text)
         self.assertEqual(session_info_container.find_element_by_css_selector(".other-session .time").text, "not yet scheduled")
@@ -118,6 +125,7 @@ class EditMeetingScheduleTests(IetfSeleniumTestCase):
         self.driver.find_element_by_css_selector('.scheduling-panel').click()
 
         self.assertEqual(session_info_container.find_elements_by_css_selector(".title"), [])
+        self.assertNotIn('other-session-selected', s2b_element.get_attribute('class'))
 
         # unschedule
 

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1175,6 +1175,12 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   background-color: #ddd;
 }
 
+.edit-meeting-schedule .session.hidden-parent * {
+  /* This makes .session.hidden-parent's children transparent but keeps the
+   * .session itself opaque so the timeslot label does not show through. */
+  opacity: 0.7;
+}
+
 .edit-meeting-schedule .session.selected .session-label {
   font-weight: bold;
 }
@@ -1198,7 +1204,7 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 }
 
 .edit-meeting-schedule .timeslot.overfull .session {
-  border-radius: 0.4em 0 0 0.4em; /* remove bottom rounding to illude to being cut off */
+  border-radius: 0.4em 0 0 0.4em; /* remove right-side rounding to allude to being cut off */
   margin-right: 0;
 }
 

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1129,7 +1129,7 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 }
 
 .edit-meeting-schedule .edit-grid .timeslot.overfull {
-  border-right: 2px dashed #fff; /* cut-off illusion */
+  border-right: 0.3em dashed #f55000; /* cut-off illusion */
 }
 
 .edit-meeting-schedule .edit-grid .timeslot.would-violate-hint {

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1164,6 +1164,11 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 
 .edit-meeting-schedule .session.selected {
   cursor: grabbing;
+  outline: #0000ff solid 0.2em; /* blue, width matches margin on .session */
+}
+
+.edit-meeting-schedule .session.other-session-selected {
+  outline: #00008b solid 0.2em; /* darkblue, width matches margin on .session */
 }
 
 .edit-meeting-schedule .read-only .session.selected {
@@ -1186,6 +1191,7 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 }
 
 .edit-meeting-schedule .session.highlight {
+  outline-color: #ff8c00;  /* darkorange */
   background-color: #f3f3f3;
 }
 
@@ -1426,7 +1432,6 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   height: 19px;
   top: 0px;
   font-size: 13px;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1177,6 +1177,9 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   background-color: #f3f3f3;
 }
 
+.edit-meeting-schedule .session.would-violate-hint {
+    outline: 0.3em solid #F55000;
+}
 .edit-meeting-schedule .session.highlight .session-label {
   font-weight: bold;
 }

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1080,6 +1080,11 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
     align-items: center;
 }
 
+.edit-meeting-schedule .edit-grid .time-header .time-label.would-violate-hint {
+    background-color: #ffe0e0;
+    outline: #ffe0e0 solid 0.4em;
+}
+
 .edit-meeting-schedule .edit-grid .time-header .time-label span {
     display: inline-block;
     width: 100%;
@@ -1129,6 +1134,7 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 
 .edit-meeting-schedule .edit-grid .timeslot.would-violate-hint {
   background-color: #ffe0e0;
+  outline: #ffe0e0 solid 0.4em;
 }
 
 .edit-meeting-schedule .constraints .encircled,
@@ -1179,7 +1185,9 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 
 .edit-meeting-schedule .session.would-violate-hint {
     outline: 0.3em solid #F55000;
+    z-index: 1; /* raise up so the outline is not overdrawn */
 }
+
 .edit-meeting-schedule .session.highlight .session-label {
   font-weight: bold;
 }

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -40,6 +40,7 @@ jQuery(document).ready(function () {
 
     // selecting
     function selectSessionElement(element) {
+        sessions.removeClass("other-session-selected");
         if (element) {
             sessions.not(element).removeClass("selected");
             jQuery(element).addClass("selected");
@@ -54,8 +55,11 @@ jQuery(document).ready(function () {
             sessionInfoContainer.find(".time").text(jQuery(element).closest(".timeslot").data('scheduledatlabel'));
 
             sessionInfoContainer.find(".other-session").each(function () {
-                let scheduledAt = sessions.filter("#session" + this.dataset.othersessionid).closest(".timeslot").data('scheduledatlabel');
+                let otherSessionElement = sessions.filter("#session" + this.dataset.othersessionid).first();
+                let scheduledAt = otherSessionElement.closest(".timeslot").data('scheduledatlabel');
                 let timeElement = jQuery(this).find(".time");
+
+                otherSessionElement.addClass("other-session-selected");
                 if (scheduledAt)
                     timeElement.text(timeElement.data("scheduled").replace("{time}", scheduledAt));
                 else

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -168,7 +168,10 @@ jQuery(document).ready(function () {
 
     sessions.on("click", function (event) {
         event.stopPropagation();
-        selectSessionElement(this);
+        // do not allow hidden sessions to be selected
+        if (!jQuery(this).hasClass('hidden-parent')) {
+            selectSessionElement(this);
+        }
     });
 
 
@@ -478,14 +481,19 @@ jQuery(document).ready(function () {
     // toggling visible sessions by session parents
     let sessionParentInputs = content.find(".session-parent-toggles input");
 
+    function setSessionHidden(sess, hide) {
+        sess.toggleClass('hidden-parent', hide);
+        sess.prop('draggable', !hide);
+    }
+
     function updateSessionParentToggling() {
         let checked = [];
         sessionParentInputs.filter(":checked").each(function () {
             checked.push(".parent-" + this.value);
         });
 
-        sessions.not(".untoggleable").filter(checked.join(",")).show();
-        sessions.not(".untoggleable").not(checked.join(",")).hide();
+        setSessionHidden(sessions.not(".untoggleable").filter(checked.join(",")), false);
+        setSessionHidden(sessions.not(".untoggleable").not(checked.join(",")), true);
     }
 
     sessionParentInputs.on("click", updateSessionParentToggling);

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function () {
 
     let sessions = content.find(".session").not(".readonly");
     let timeslots = content.find(".timeslot");
+    let timeslotLabels = content.find(".time-label");
     let days = content.find(".day-flow .day");
 
     // hack to work around lack of position sticky support in old browsers, see https://caniuse.com/#feat=css-sticky
@@ -81,6 +82,39 @@ jQuery(document).ready(function () {
         constraintElt.toggleClass('would-violate-hint', wouldViolate);  // and the specific constraint
     }
 
+    /**
+     * Mark or unmark a timeslot that conflicts with the selected session
+     *
+     * If wholeInterval is true, marks the entire column in addition to the timeslot.
+     * This currently works by setting the class for the timeslot and the time-label
+     * in its column. Because this is called for every timeslot in the interval, the
+     * overall effect is to highlight the entire column.
+     *
+     * @param timeslotElt Timeslot element to be marked/unmarked
+     * @param wouldViolate True to mark or false to unmark
+     * @param wholeInterval Should the entire time interval be flagged or just the timeslot?
+     */
+    function setTimeslotWouldViolate(timeslotElt, wouldViolate, wholeInterval) {
+        timeslotElt = jQuery(timeslotElt);
+        timeslotElt.toggleClass('would-violate-hint', wouldViolate);
+        if (wholeInterval) {
+            let index = timeslotElt.index(); // position of this timeslot relative to its container
+            let label = timeslotElt
+                          .closest('div.room-group')
+                          .find('div.time-header .time-label')
+                          .get(index); // get time-label corresponding to this timeslot
+            jQuery(label).toggleClass('would-violate-hint', wouldViolate);
+        }
+    }
+
+    /**
+     * Remove all would-violate-hint classes on timeslots
+     */
+    function resetTimeslotsWouldViolate() {
+        timeslots.removeClass("would-violate-hint");
+        timeslotLabels.removeClass("would-violate-hint");
+    }
+
     function showConstraintHints(selectedSession) {
         let sessionId = selectedSession ? selectedSession.id.slice("session".length) : null;
         // hints on the sessions
@@ -102,7 +136,7 @@ jQuery(document).ready(function () {
         });
 
         // hints on timeslots
-        timeslots.removeClass("would-violate-hint");
+        resetTimeslotsWouldViolate();
         if (selectedSession) {
             let intervals = [];
             timeslots.filter(":has(.session .constraints > span.would-violate-hint)").each(function () {
@@ -110,15 +144,17 @@ jQuery(document).ready(function () {
             });
 
             let overlappingTimeslots = findTimeslotsOverlapping(intervals);
-            for (let i = 0; i < overlappingTimeslots.length; ++i)
-                overlappingTimeslots[i].addClass("would-violate-hint");
+            for (let i = 0; i < overlappingTimeslots.length; ++i) {
+                setTimeslotWouldViolate(overlappingTimeslots[i], true, true);
+            }
 
             // check room sizes
             let attendees = +selectedSession.dataset.attendees;
             if (attendees) {
                 timeslots.not(".would-violate-hint").each(function () {
-                    if (attendees > +jQuery(this).closest(".timeslots").data("roomcapacity"))
-                        jQuery(this).addClass("would-violate-hint");
+                    if (attendees > +jQuery(this).closest(".timeslots").data("roomcapacity")) {
+                        setTimeslotWouldViolate(this, true, false);
+                    }
                 });
             }
         }

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -68,21 +68,37 @@ jQuery(document).ready(function () {
         }
     }
 
+    /**
+     * Mark or unmark a session that conflicts with the selected session
+     *
+     * @param constraintElt The element corresponding to the specific constraint
+     * @param wouldViolate True to mark or false to unmark
+     */
+    function setSessionWouldViolate(constraintElt, wouldViolate) {
+        constraintElt = jQuery(constraintElt);
+        let constraintDiv = constraintElt.closest('div.session');  // find enclosing session div
+        constraintDiv.toggleClass('would-violate-hint', wouldViolate);  // mark the session container
+        constraintElt.toggleClass('would-violate-hint', wouldViolate);  // and the specific constraint
+    }
+
     function showConstraintHints(selectedSession) {
         let sessionId = selectedSession ? selectedSession.id.slice("session".length) : null;
         // hints on the sessions
         sessions.find(".constraints > span").each(function () {
-            if (!sessionId) {
-                jQuery(this).removeClass("would-violate-hint");
-                return;
+            let wouldViolate = false;
+            let applyChange = true;
+            if (sessionId) {
+                let sessionIds = this.dataset.sessions;
+                if (!sessionIds) {
+                    applyChange = False;
+                } else {
+                    wouldViolate = sessionIds.split(",").indexOf(sessionId) !== -1;
+                }
             }
 
-            let sessionIds = this.dataset.sessions;
-            if (!sessionIds)
-                return;
-
-            let wouldViolate = sessionIds.split(",").indexOf(sessionId) != -1;
-            jQuery(this).toggleClass("would-violate-hint", wouldViolate);
+            if (applyChange) {
+                setSessionWouldViolate(this, wouldViolate);
+            }
         });
 
         // hints on timeslots

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -10,6 +10,7 @@
     .parent-{{ parent.acronym }} { background-image: linear-gradient(to right, {{ parent.scheduling_color }} 0.4em, transparent 0.5em); }
     .parent-{{ parent.acronym }}.hidden-parent { filter: blur(3px); }{# blur masks contents but keeps the parent color visible #}
     .parent-{{ parent.acronym }}.selected { background-color: {{ parent.light_scheduling_color }}; }
+    .parent-{{ parent.acronym }}.other-session-selected { background-color: {{ parent.light_scheduling_color }}; }
   {% endfor %}
 {% endblock morecss %}
 

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -7,7 +7,8 @@
 {% block morecss %}
   {# set the group colors with CSS here #}
   {% for parent in session_parents %}
-    .parent-{{ parent.acronym }} { background: linear-gradient(to right, {{ parent.scheduling_color }} 0.4em, transparent 0.5em); }
+    .parent-{{ parent.acronym }} { background-image: linear-gradient(to right, {{ parent.scheduling_color }} 0.4em, transparent 0.5em); }
+    .parent-{{ parent.acronym }}.hidden-parent { filter: blur(3px); }{# blur masks contents but keeps the parent color visible #}
     .parent-{{ parent.acronym }}.selected { background-color: {{ parent.light_scheduling_color }}; }
   {% endfor %}
 {% endblock morecss %}


### PR DESCRIPTION
This addresses [ticket 3219](https://trac.ietf.org/trac/ietfdb/ticket/3219).

This adds a blue box around the currently selected session and a dark blue box around any other sessions belonging to its group.

Note that there's a random bit of cleanup - I removed a doubly-specified 'hidden' value in the CSS.

Finally, the first five commits are included in #14 and #15. Ignore those for this review and only look at the last commit.