### PR TITLE
Add option to swap columns on schedule editor

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -790,6 +790,10 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
             return HttpResponseRedirect(request.get_full_path())
 
         elif action == 'swaptimeslots':
+            # Swap sets of timeslots with equal start/end time for a given set of rooms.
+            # Gets start and end times from TimeSlot instances for the origin and target,
+            # then swaps all timeslots for the requested rooms whose start/end match those.
+            # The origin/target timeslots do not need to be the same duration.
             swap_timeslots_form = SwapTimeslotsForm(meeting, request.POST)
             if not swap_timeslots_form.is_valid():
                 return HttpResponse("Invalid swap: {}".format(swap_timeslots_form.errors), status=400)

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -56,7 +56,7 @@ from ietf.ietfauth.utils import role_required, has_role, user_is_person
 from ietf.mailtrigger.utils import gather_address_lists
 from ietf.meeting.models import Meeting, Session, Schedule, FloorPlan, SessionPresentation, TimeSlot, SlideSubmission
 from ietf.meeting.models import SessionStatusName, SchedulingEvent, SchedTimeSessAssignment, Room, TimeSlotTypeName
-from ietf.meeting.forms import CustomDurationField
+from ietf.meeting.forms import CustomDurationField, SwapDaysForm, SwapTimeslotsForm
 from ietf.meeting.helpers import get_areas, get_person_by_email, get_schedule_by_name
 from ietf.meeting.helpers import build_all_agenda_slices, get_wg_name_list
 from ietf.meeting.helpers import get_all_assignments_from_schedule
@@ -455,11 +455,6 @@ def new_meeting_schedule(request, num, owner=None, name=None):
         'form': form,
     })
 
-
-class SwapDaysForm(forms.Form):
-    source_day = forms.DateField(required=True)
-    target_day = forms.DateField(required=True)
-
 @ensure_csrf_cookie
 def edit_meeting_schedule(request, num=None, owner=None, name=None):
     meeting = get_meeting(num)
@@ -792,6 +787,33 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
             target_timeslots = [ts for ts in timeslots_qs if ts.time.date() == target_day]
             swap_meeting_schedule_timeslot_assignments(schedule, source_timeslots, target_timeslots, target_day - source_day)
 
+            return HttpResponseRedirect(request.get_full_path())
+
+        elif action == 'swaptimeslots':
+            swap_timeslots_form = SwapTimeslotsForm(meeting, request.POST)
+            if not swap_timeslots_form.is_valid():
+                return HttpResponse("Invalid swap: {}".format(swap_timeslots_form.errors), status=400)
+
+            affected_rooms = swap_timeslots_form.cleaned_data['rooms']
+            origin_timeslot = swap_timeslots_form.cleaned_data['origin_timeslot']
+            target_timeslot = swap_timeslots_form.cleaned_data['target_timeslot']
+
+            origin_timeslots = meeting.timeslot_set.filter(
+                location__in=affected_rooms,
+                time=origin_timeslot.time,
+                duration=origin_timeslot.duration,
+            )
+            target_timeslots = meeting.timeslot_set.filter(
+                location__in=affected_rooms,
+                time=target_timeslot.time,
+                duration=target_timeslot.duration,
+            )
+            swap_meeting_schedule_timeslot_assignments(
+                schedule,
+                list(origin_timeslots),
+                list(target_timeslots),
+                target_timeslot.time - origin_timeslot.time,
+            )
             return HttpResponseRedirect(request.get_full_path())
 
         return HttpResponse("Invalid parameters", status=400)

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1355,6 +1355,21 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   cursor: pointer;
 }
 
+.edit-meeting-schedule .modal .day-options {
+    display: flex;
+    flex-flow: row wrap;
+}
+
+.edit-meeting-schedule .modal .timeslot-options {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+}
+
+.edit-meeting-schedule .modal .room-group {
+    margin: 2em;
+}
+
 .edit-meeting-schedule .scheduling-panel .session-info-container {
   padding-left: 0.5em;
   flex: 0 0 25em;

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -290,49 +290,68 @@ jQuery(document).ready(function () {
             }
         });
 
+
+        let updateSwapSubmitButton = function (modal, inputName) {
+            modal.find("button[type=submit]").prop(
+              "disabled",
+              modal.find("input[name='" + inputName + "']:checked").length === 0
+            );
+        };
+
         // swap days
+        let swapDaysModal = content.find("#swap-days-modal");
+        let swapDaysRadios = swapDaysModal.find(".modal-body label");
+        let updateSwapDaysSubmitButton = function () {
+            updateSwapSubmitButton(swapDaysModal, 'target_day')
+        };
         content.find(".swap-days").on("click", function () {
             let originDay = this.dataset.dayid;
-            let modal = content.find("#swap-days-modal");
-            let radios = modal.find(".modal-body label");
-            radios.removeClass("text-muted");
-            radios.find("input[name='target_day']").prop("disabled", false).prop("checked", false);
+            swapDaysRadios.removeClass("text-muted");
+            swapDaysRadios.find("input[name='target_day']").prop("disabled", false).prop("checked", false);
 
-            let originRadio = radios.find("input[name=target_day][value=" + originDay + "]");
+            let originRadio = swapDaysRadios.find("input[name=target_day][value=" + originDay + "]");
             originRadio.parent().addClass("text-muted");
             originRadio.prop("disabled", true);
 
-            modal.find(".modal-title .day").text(jQuery.trim(originRadio.parent().text()));
-            modal.find("input[name=source_day]").val(originDay);
+            swapDaysModal.find(".modal-title .day").text(jQuery.trim(originRadio.parent().text()));
+            swapDaysModal.find("input[name=source_day]").val(originDay);
 
             updateSwapDaysSubmitButton();
+            swapDaysModal.modal('show'); // show via JS so it won't open until it is initialized
         });
 
-        function updateSwapDaysSubmitButton() {
-            content.find("#swap-days-modal button[type=submit]").prop("disabled", content.find("#swap-days-modal input[name=target_day]:checked").length == 0);
-        }
-
-        content.find("#swap-days-modal input[name=target_day]").on("change", function () {
+        swapDaysModal.find("input[name=target_day]").on("change", function () {
             updateSwapDaysSubmitButton();
         });
 
         // swap timeslot columns
+        let swapTimeslotsModal = content.find('#swap-timeslot-col-modal');
+        let swapTimeslotsRadios = swapTimeslotsModal.find(".modal-body label");
+        let updateSwapTimeslotsSubmitButton = function () {
+            updateSwapSubmitButton(swapTimeslotsModal, 'target_timeslot');
+        };
         content.find('.swap-timeslot-col').on('click', function() {
             let roomGroup = this.closest('.room-group').dataset;
-            let modal = content.find('#swap-timeslot-col-modal');
-            let radios = modal.find(".modal-body label");
-            radios.removeClass('text-muted');
-            radios.find("input[name=target_timeslot]").prop("disabled", false).prop("checked", false);
+            swapTimeslotsRadios.removeClass('text-muted');
+            swapTimeslotsRadios.find("input[name=target_timeslot]").prop("disabled", false).prop("checked", false);
 
-            modal.find('.room-group').hide();
-            modal.find('.room-group-' + roomGroup.index).show();
+            swapTimeslotsModal.find('.room-group').hide();
+            swapTimeslotsModal.find('.room-group-' + roomGroup.index).show();
 
-            let originRadio = radios.find('input[value="' + this.dataset.timeslotPk +'"]');
+            let originRadio = swapTimeslotsRadios.find('input[value="' + this.dataset.timeslotPk +'"]');
             originRadio.parent().addClass('text-muted');
             originRadio.prop('disabled', true);
-            modal.find('.modal-title .origin-label').text(this.dataset.originLabel);
-            modal.find('input[name="origin_timeslot"]').val(this.dataset.timeslotPk);
-            modal.find('input[name="rooms"]').val(roomGroup.rooms);
+            swapTimeslotsModal.find('.modal-title .origin-label').text(this.dataset.originLabel);
+            swapTimeslotsModal.find('input[name="origin_timeslot"]').val(this.dataset.timeslotPk);
+            swapTimeslotsModal.find('input[name="rooms"]').val(roomGroup.rooms);
+
+            // Open the modal via JS so it won't open until it is initialized
+            updateSwapTimeslotsSubmitButton();
+            swapTimeslotsModal.modal('show');
+        });
+
+        swapTimeslotsModal.find("input[name=target_timeslot]").on("change", function () {
+            updateSwapTimeslotsSubmitButton();
         });
     }
 

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -331,6 +331,8 @@ jQuery(document).ready(function () {
             originRadio.parent().addClass('text-muted');
             originRadio.prop('disabled', true);
             modal.find('.modal-title .origin-label').text(this.dataset.originLabel);
+            modal.find('input[name="origin_timeslot"]').val(this.dataset.timeslotPk);
+            modal.find('input[name="rooms"]').val(this.dataset.roomPks);
         })
     }
 

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -291,6 +291,8 @@ jQuery(document).ready(function () {
         });
 
 
+        // Helpers for swap days / timeslots
+        // Enable or disable a swap modal's submit button
         let updateSwapSubmitButton = function (modal, inputName) {
             modal.find("button[type=submit]").prop(
               "disabled",
@@ -298,50 +300,62 @@ jQuery(document).ready(function () {
             );
         };
 
+        // Disable a particular swap modal radio input
+        let updateSwapRadios = function (labels, radios, disableValue) {
+          labels.removeClass('text-muted');
+          radios.prop('disabled', false);
+          radios.prop('checked', false);
+          let disableInput = radios.filter('[value="' + disableValue + '"]');
+          if (disableInput) {
+              disableInput.parent().addClass('text-muted');
+              disableInput.prop('disabled', true);
+          }
+          return disableInput; // return the input that was disabled, if any
+        };
+
         // swap days
         let swapDaysModal = content.find("#swap-days-modal");
-        let swapDaysRadios = swapDaysModal.find(".modal-body label");
+        let swapDaysLabels = swapDaysModal.find(".modal-body label");
+        let swapDaysRadios = swapDaysLabels.find('input[name=target_day]');
         let updateSwapDaysSubmitButton = function () {
             updateSwapSubmitButton(swapDaysModal, 'target_day')
         };
+        // handler to prep and open the modal
         content.find(".swap-days").on("click", function () {
             let originDay = this.dataset.dayid;
-            swapDaysRadios.removeClass("text-muted");
-            swapDaysRadios.find("input[name='target_day']").prop("disabled", false).prop("checked", false);
+            originRadio = updateSwapRadios(swapDaysLabels, swapDaysRadios, originDay);
 
-            let originRadio = swapDaysRadios.find("input[name=target_day][value=" + originDay + "]");
-            originRadio.parent().addClass("text-muted");
-            originRadio.prop("disabled", true);
-
+            // Fill in label in the modal title
             swapDaysModal.find(".modal-title .day").text(jQuery.trim(originRadio.parent().text()));
+
+            // Fill in the hidden form fields
             swapDaysModal.find("input[name=source_day]").val(originDay);
 
             updateSwapDaysSubmitButton();
             swapDaysModal.modal('show'); // show via JS so it won't open until it is initialized
         });
-
-        swapDaysModal.find("input[name=target_day]").on("change", function () {
-            updateSwapDaysSubmitButton();
-        });
+        swapDaysRadios.on("change", function () {updateSwapDaysSubmitButton()});
 
         // swap timeslot columns
         let swapTimeslotsModal = content.find('#swap-timeslot-col-modal');
-        let swapTimeslotsRadios = swapTimeslotsModal.find(".modal-body label");
+        let swapTimeslotsLabels = swapTimeslotsModal.find(".modal-body label");
+        let swapTimeslotsRadios = swapTimeslotsLabels.find('input[name=target_timeslot]');
         let updateSwapTimeslotsSubmitButton = function () {
             updateSwapSubmitButton(swapTimeslotsModal, 'target_timeslot');
         };
+        // handler to prep and open the modal
         content.find('.swap-timeslot-col').on('click', function() {
             let roomGroup = this.closest('.room-group').dataset;
-            swapTimeslotsRadios.removeClass('text-muted');
-            swapTimeslotsRadios.find("input[name=target_timeslot]").prop("disabled", false).prop("checked", false);
+            updateSwapRadios(swapTimeslotsLabels, swapTimeslotsRadios, this.dataset.timeslotPk)
 
+            // show only options for this room group
             swapTimeslotsModal.find('.room-group').hide();
             swapTimeslotsModal.find('.room-group-' + roomGroup.index).show();
 
-            let originRadio = swapTimeslotsRadios.find('input[value="' + this.dataset.timeslotPk +'"]');
-            originRadio.parent().addClass('text-muted');
-            originRadio.prop('disabled', true);
+            // Fill in label in the modal title
             swapTimeslotsModal.find('.modal-title .origin-label').text(this.dataset.originLabel);
+
+            // Fill in the hidden form fields
             swapTimeslotsModal.find('input[name="origin_timeslot"]').val(this.dataset.timeslotPk);
             swapTimeslotsModal.find('input[name="rooms"]').val(roomGroup.rooms);
 
@@ -349,10 +363,7 @@ jQuery(document).ready(function () {
             updateSwapTimeslotsSubmitButton();
             swapTimeslotsModal.modal('show');
         });
-
-        swapTimeslotsModal.find("input[name=target_timeslot]").on("change", function () {
-            updateSwapTimeslotsSubmitButton();
-        });
+        swapTimeslotsRadios.on("change", function () {updateSwapTimeslotsSubmitButton()});
     }
 
     // hints for the current schedule

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -296,7 +296,7 @@ jQuery(document).ready(function () {
             let modal = content.find("#swap-days-modal");
             let radios = modal.find(".modal-body label");
             radios.removeClass("text-muted");
-            radios.find("input[name=target_day]").prop("disabled", false).prop("checked", false);
+            radios.find("input[name='target_day']").prop("disabled", false).prop("checked", false);
 
             let originRadio = radios.find("input[name=target_day][value=" + originDay + "]");
             originRadio.parent().addClass("text-muted");
@@ -315,6 +315,23 @@ jQuery(document).ready(function () {
         content.find("#swap-days-modal input[name=target_day]").on("change", function () {
             updateSwapDaysSubmitButton();
         });
+
+        // swap timeslot columns
+        content.find('.swap-timeslot-col').on('click', function() {
+            let roomGroup = this.dataset.roomGroup;
+            let modal = content.find('#swap-timeslot-col-modal');
+            let radios = modal.find(".modal-body label");
+            radios.removeClass('text-muted');
+            radios.find("input[name=target_timeslot]").prop("disabled", false).prop("checked", false);
+
+            modal.find('.room-group').hide();
+            modal.find('.room-group-' + roomGroup).show();
+
+            let originRadio = radios.find('input[value="' + this.dataset.timeslotPk +'"]');
+            originRadio.parent().addClass('text-muted');
+            originRadio.prop('disabled', true);
+            modal.find('.modal-title .origin-label').text(this.dataset.originLabel);
+        })
     }
 
     // hints for the current schedule

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -318,22 +318,22 @@ jQuery(document).ready(function () {
 
         // swap timeslot columns
         content.find('.swap-timeslot-col').on('click', function() {
-            let roomGroup = this.dataset.roomGroup;
+            let roomGroup = this.closest('.room-group').dataset;
             let modal = content.find('#swap-timeslot-col-modal');
             let radios = modal.find(".modal-body label");
             radios.removeClass('text-muted');
             radios.find("input[name=target_timeslot]").prop("disabled", false).prop("checked", false);
 
             modal.find('.room-group').hide();
-            modal.find('.room-group-' + roomGroup).show();
+            modal.find('.room-group-' + roomGroup.index).show();
 
             let originRadio = radios.find('input[value="' + this.dataset.timeslotPk +'"]');
             originRadio.parent().addClass('text-muted');
             originRadio.prop('disabled', true);
             modal.find('.modal-title .origin-label').text(this.dataset.originLabel);
             modal.find('input[name="origin_timeslot"]').val(this.dataset.timeslotPk);
-            modal.find('input[name="rooms"]').val(this.dataset.roomPks);
-        })
+            modal.find('input[name="rooms"]').val(roomGroup.rooms);
+        });
     }
 
     // hints for the current schedule

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -323,7 +323,7 @@ jQuery(document).ready(function () {
         // handler to prep and open the modal
         content.find(".swap-days").on("click", function () {
             let originDay = this.dataset.dayid;
-            originRadio = updateSwapRadios(swapDaysLabels, swapDaysRadios, originDay);
+            let originRadio = updateSwapRadios(swapDaysLabels, swapDaysRadios, originDay);
 
             // Fill in label in the modal title
             swapDaysModal.find(".modal-title .day").text(jQuery.trim(originRadio.parent().text()));

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -90,7 +90,7 @@
         {% for day, day_data in days.items %}
           <div class="day">
             <div class="day-label">
-              <strong>{{ day|date:"l" }}</strong> <i class="fa fa-exchange swap-days" data-dayid="{{ day.isoformat }}" data-toggle="modal" data-target="#swap-days-modal"></i><br>
+              <strong>{{ day|date:"l" }}</strong> <i class="fa fa-exchange swap-days" data-dayid="{{ day.isoformat }}"></i><br>
               {{ day|date:"N j, Y" }}
             </div>
 
@@ -106,8 +106,7 @@
                         {{ t.time|date:"G:i" }} - {{ t.end_time|date:"G:i" }}
                         <i class="fa fa-exchange swap-timeslot-col"
                            data-origin-label="{{ day|date:"l, N j" }}, {{ t.time|date:"G:i" }}-{{ t.end_time|date:"G:i" }}"
-                           data-timeslot-pk="{{ t.pk }}"
-                           data-toggle="modal" data-target="#swap-timeslot-col-modal"></i>
+                           data-timeslot-pk="{{ t.pk }}"></i>
                       </span>
                     </div>
                   {% endfor %}

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -99,7 +99,17 @@
                 <div class="time-header">
                   {# All rooms in a group have same timeslots; grab the first for the labels #}
                   {% for t in rgroup.0.timeslots %}
-                    <div class="time-label" style="width: {{ t.layout_width }}rem"><span>{{ t.time|date:"G:i" }} - {{ t.end_time|date:"G:i" }}</span></div>
+                    <div class="time-label" style="width: {{ t.layout_width }}rem">
+                      <span>
+                        {{ t.time|date:"G:i" }} - {{ t.end_time|date:"G:i" }}
+                        <i class="fa fa-exchange swap-timeslot-col"
+                           data-room-group="{{ forloop.parentloop.counter0 }}"
+                           data-origin-label="{{ day|date:"l, N j" }}, {{ t.time|date:"G:i" }}-{{ t.end_time|date:"G:i" }}"
+                           data-timeslot-pk="{{ t.pk }}"
+                           data-room-pks="{% for r in rgroup %}{{ r.room.pk }},{% endfor %}"
+                           data-toggle="modal" data-target="#swap-timeslot-col-modal"></i>
+                      </span>
+                    </div>
                   {% endfor %}
                 </div>
                 {% for room_data in rgroup %}{% with room_data.room as room %}
@@ -211,6 +221,50 @@
                 <input type="radio" name="target_day" value="{{ day.isoformat }}"> {{ day|date:"l, N j, Y" }}
               </label>
             {% endfor %}
+          </div>
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            <button type="submit" name="action" value="swapdays" class="btn btn-primary">Swap days</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div id="swap-timeslot-col-modal" class="modal" role="dialog" aria-labelledby="swap-timeslot-col-modal-title">
+      <div class="modal-dialog modal-lg" role="document">
+        <form class="modal-content" method="post">{% csrf_token %}
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">
+              <span aria-hidden="true">&times;</span>
+              <span class="sr-only">Close</span>
+            </button>
+            <h4 class="modal-title" id="swap-timeslot-col-modal-title">
+              Swap <span class="origin-label"></span> with</h4>
+          </div>
+
+          <input type="hidden" name="source_timeslot_pk" value="">
+          <input type="hidden" name="source_room_pks" value="">
+
+          <div class="modal-body">
+              <div class="day-options">
+            {% for day, day_data in days.items %}
+              {% for rgroup in day_data %}
+              <div class="room-group room-group-{{ forloop.counter0 }}">
+                {% if rgroup.0.timeslots|length > 0 %}
+                  {{ day|date:"l, N j" }}
+                  <div class="timeslot-options">
+                    {% for t in rgroup.0.timeslots %}
+                      <label>
+                        <input type="radio" name="target_timeslot" value="{{ t.pk }}">{{ t.time|date:"G:i" }}-{{ t.end_time|date:"G:i" }}
+                      </label>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
+              {% endfor %}
+            {% endfor %}
+              </div>
           </div>
 
           <div class="modal-footer">

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -106,7 +106,7 @@
                            data-room-group="{{ forloop.parentloop.counter0 }}"
                            data-origin-label="{{ day|date:"l, N j" }}, {{ t.time|date:"G:i" }}-{{ t.end_time|date:"G:i" }}"
                            data-timeslot-pk="{{ t.pk }}"
-                           data-room-pks="{% for r in rgroup %}{{ r.room.pk }},{% endfor %}"
+                           data-room-pks="{% for r in rgroup %}{{ r.room.pk }}{% if not forloop.last %},{% endif %}{% endfor %}"
                            data-toggle="modal" data-target="#swap-timeslot-col-modal"></i>
                       </span>
                     </div>
@@ -243,8 +243,8 @@
               Swap <span class="origin-label"></span> with</h4>
           </div>
 
-          <input type="hidden" name="source_timeslot_pk" value="">
-          <input type="hidden" name="source_room_pks" value="">
+          <input type="hidden" name="origin_timeslot" value="">
+          <input type="hidden" name="rooms" value="">
 
           <div class="modal-body">
               <div class="day-options">
@@ -269,7 +269,7 @@
 
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            <button type="submit" name="action" value="swapdays" class="btn btn-primary">Swap days</button>
+            <button type="submit" name="action" value="swaptimeslots" class="btn btn-primary">Swap timeslots</button>
           </div>
         </form>
       </div>

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -95,7 +95,9 @@
             </div>
 
             {% for rgroup in day_data %}
-              <div class="room-group">
+              <div class="room-group"
+                   data-index="{{ forloop.counter0 }}"
+                   data-rooms="{% for r in rgroup %}{{ r.room.pk }}{% if not forloop.last %},{% endif %}{% endfor %}">
                 <div class="time-header">
                   {# All rooms in a group have same timeslots; grab the first for the labels #}
                   {% for t in rgroup.0.timeslots %}
@@ -103,10 +105,8 @@
                       <span>
                         {{ t.time|date:"G:i" }} - {{ t.end_time|date:"G:i" }}
                         <i class="fa fa-exchange swap-timeslot-col"
-                           data-room-group="{{ forloop.parentloop.counter0 }}"
                            data-origin-label="{{ day|date:"l, N j" }}, {{ t.time|date:"G:i" }}-{{ t.end_time|date:"G:i" }}"
                            data-timeslot-pk="{{ t.pk }}"
-                           data-room-pks="{% for r in rgroup %}{{ r.room.pk }}{% if not forloop.last %},{% endif %}{% endfor %}"
                            data-toggle="modal" data-target="#swap-timeslot-col-modal"></i>
                       </span>
                     </div>


### PR DESCRIPTION
This addresses [ticket 3216](https://trac.ietf.org/trac/ietfdb/ticket/3216).

Note that I've created a funky dev branch containing our previous dev/7.31.0 plus the 7.32.0 updates. This is needed as a target because the work from #6 (timeslot time label headers) did not make it into the 7.32.0 release, but that work is relied upon here.

This adds a button to the timeslot headers, similar to the button on the day label headers, that opens a modal for swapping timeslots. Clicking the new one allows moving the contents of that column to another column. This acts on one room group at a time - swapping between room groups is not allowed (nor would it make sense because the swap preserves session location).