### PR TITLE
Run v2v3 converter internally when v2 XML is submitted

### DIFF
--- a/ietf/submit/test_submission_v2_country_only.xml
+++ b/ietf/submit/test_submission_v2_country_only.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" []>
+<?rfc toc="yes"?>
+<rfc category="info" docName="%(name)s" ipr="trust200902">
+  <front>
+    <title>%(title)s</title>
+    <author fullname="%(author)s" initials="%(initials)s" surname="%(surname)s">
+      <organization>Test Centre Inc.</organization>
+      <address>
+        <postal>
+          <country>UK</country>
+        </postal>
+        <email>%(email)s</email>
+      </address>
+    </author>
+    <date day="%(day)s" month="%(month)s" year="%(year)s"/>
+    <workgroup>%(group)s</workgroup>
+    <abstract>
+      <t>
+         This document describes how to test tests.
+      </t>
+    </abstract>
+  </front>
+  <middle>
+    <section numbered="true" toc="default" title="Introduction">
+      <t>
+         This document describes a protocol for testing tests.
+      </t>
+    </section>
+    <section anchor="JSON" numbered="true" toc="default" title="JSON example">
+      <t>
+   The JSON object should look like this:
+
+   {
+       "test": 1234
+   }
+      </t>
+    </section>
+    <section anchor="Security" numbered="true" toc="default" title="Security Considerations">
+      <t>
+         There are none.
+      </t>
+    </section>
+    <section anchor="IANA" numbered="true" toc="default" title="IANA Considerations">
+      <t>
+         No new registrations for IANA.
+      </t>
+    </section>
+  </middle>
+  <back/>
+</rfc>

--- a/ietf/submit/tests.py
+++ b/ietf/submit/tests.py
@@ -1244,6 +1244,27 @@ class SubmitTests(TestCase):
 
         self.assertEqual(Submission.objects.get(name=name).group.acronym, group.acronym)
 
+    def test_submit_new_wg_v2_country_only(self):
+        """V2 drafts should accept addresses without street/city"""
+        # break early in case of missing configuration
+        self.assertTrue(os.path.exists(settings.IDSUBMIT_IDNITS_BINARY))
+
+        # submit
+        author = PersonFactory()
+        group = GroupFactory()
+        name = "draft-authorname-testing-tests"
+        r = self.create_and_post_submission(
+            name=name,
+            rev='00',
+            author=author,
+            group=group.acronym,
+            formats=('xml',),
+            base_filename='test_submission_v2_country_only'
+        )
+        self.assertEqual(r.status_code, 302)
+        submission = Submission.objects.get(name=name)
+        self.assertEqual(submission.xml_version, '2')  # should reflect the submitted version
+
     def test_submit_new_irtf(self):
         group = Group.objects.create(acronym="saturnrg", name="Saturn", type_id="rg", state_id="active")
 


### PR DESCRIPTION
Addresses [ticket 3305](https://trac.ietf.org/trac/ietfdb/ticket/3305).

The main purpose is to call the v2v3 converter in xml2rfc when a v2 XML file is uploaded as a submission. This matches the behavior of the xml2rfc command line program when v2 XML is encountered and, as a side effect, resolves the initially reported issue of validation failure when an author's address does not have a street and/or city.

In addition to the minimal fix (and test), this refactors temporary file handling. The call to `mkstemp` is valid, but involves creation of an unused file handle and leads to somewhat roundabout opening and closing of file objects. Instead, the [NamedTemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) interface is used. This preserves the security features of `mkstemp` but leaves out the file handle.

Additionally, a `try...finally` that separated cleanup code from setup code by several pages of code has been refactored to use an [ExitStack](https://docs.python.org/3.6/library/contextlib.html#contextlib.ExitStack) context manager. This allows a cleanup callback to be registered at the start of the loop instead of at the very end.