### PR TITLE
Fix debug / SERVER_MODE settings

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -31,7 +31,7 @@ sys.path.append(os.path.abspath(BASE_DIR + "/.."))
 from ietf import __version__
 import debug
 
-DEBUG = False
+DEBUG = True
 debug.debug = DEBUG
 
 DEBUG_AGENDA = False
@@ -39,7 +39,7 @@ DEBUG_AGENDA = False
 # Valid values:
 # 'production', 'test', 'development'
 # Override this in settings_local.py if it's not the desired setting:
-SERVER_MODE = 'production'
+SERVER_MODE = 'development'
 
 # Domain name of the IETF
 IETF_DOMAIN = 'ietf.org'


### PR DESCRIPTION
These were out of sync at the point we started tracking dev branches.
Applying patches from one SVN dev tag to the next does not see the change
in these settings, so it stayed out of date in our git repo. Should
only have to do this once as long as we track dev.