### PR TITLE
Remove meetecho recording button from agenda items

### DIFF
--- a/ietf/templates/meeting/interim_session_buttons.html
+++ b/ietf/templates/meeting/interim_session_buttons.html
@@ -53,7 +53,7 @@
       {% elif item.timeslot.location.video_stream_url %}
 	  <a class=""
 	    href="{{item.timeslot.location.video_stream_url|format:session }}"
-	    title="Meetecho video stream"><span class="fa fa-fw fa-video-camera"></span>
+	    title="Meetecho session"><span class="fa fa-fw fa-video-camera"></span>
 	  </a>
       {% else %}
 	<span class="">
@@ -93,10 +93,6 @@
             <a class="" href="{{ href }}" title="{{ r.title }}"><span class="fa fa-fw fa-file-o"></span></a>
           {% endif %}
         {% endwith %}{% endfor %}
-      {% elif item.timeslot.location.video_stream_url %}
-          <a class=""
-             href="http://www.meetecho.com/ietf{{meeting.number}}/recordings#{{acronym.upper}}"
-             title="Meetecho session recording"><span class="fd fa-fw fd-meetecho"></span></a>
       {% elif show_empty  %}
         <span class="fa fa-fw"></span>
       {% endif %}

--- a/ietf/templates/meeting/session_buttons_include.html
+++ b/ietf/templates/meeting/session_buttons_include.html
@@ -43,7 +43,7 @@
     {% if timeslot.location.video_stream_url %}
       <a class=""
         href="{{timeslot.location.video_stream_url|format:session }}"
-        title="Meetecho video stream"><span class="fa fa-fw fa-video-camera"></span>
+        title="Meetecho session"><span class="fa fa-fw fa-video-camera"></span>
       </a>
     {% endif %}
     <!-- Audio stream -->
@@ -108,11 +108,6 @@
           {% endfor %}
         {% endif %}
       {% endwith %}
-      {% if timeslot.location.video_stream_url %}
-        <a class=""
-          href="http://www.meetecho.com/ietf{{meeting.number}}/recordings#{{acronym.upper}}"
-         title="Meetecho session recording"><span class="fd fa-fw fd-meetecho"></span></a>
-      {% endif %}
     {% endif %}
   {% endif %}
   {% endwith %}


### PR DESCRIPTION
Addresses tickets 3135 and 3223. Removes the outdated Meetecho recording button as requested in 3223. Changes the name of the remaining video link to "Meetecho session" instead of "Meetecho video stream" as requested in 3135.

This was simple enough to be committed to SVN without review as r19260.