### PR TITLE
Update session request notification emails to handle new constraint representation

### DIFF
--- a/ietf/secr/templates/includes/session_info.txt
+++ b/ietf/secr/templates/includes/session_info.txt
@@ -8,10 +8,9 @@ Session Requester: {{ login }}
 Number of Sessions: {{ session.num_session }}
 Length of Session(s):  {{ session.length_session1|display_duration }}{% if session.length_session2 %}, {{ session.length_session2|display_duration }}{% endif %}{% if session.length_session3 %}, {{ session.length_session3|display_duration }}{% endif %}
 Number of Attendees: {{ session.attendees }}
-Conflicts to Avoid: 
-{% if session.conflict1 %} Chair Conflict: {{ session.conflict1 }}{% endif %}
-{% if session.conflict2 %} Technology Overlap: {{ session.conflict2 }}{% endif %}
-{% if session.conflict3 %} Key Participant Conflict: {{ session.conflict3 }}{% endif %}
+{% if session_conflicts|length > 0 %}Conflicts to Avoid:
+{% for conflict in session_conflicts %}
+  {{ conflict.name|title }}: {{ conflict.groups }}{% endfor %}{% endif %}
 {% if session.session_time_relation_display %} {{ session.session_time_relation_display }}{% endif %}
 {% if session.adjacent_with_wg %} Adjacent with WG: {{ session.adjacent_with_wg }}{% endif %}
 {% if session.timeranges_display %} Can't meet: {{ session.timeranges_display|join:", " }}{% endif %}


### PR DESCRIPTION
Addresses [ticket 3381](https://trac.ietf.org/trac/ietfdb/ticket/3381)

  * Move reusable conflict gathering code into SessionForm
  * Replace old conflict1, -2, -3 in template with loop over actual conflict types
  * Normalize group acronym list to be space-separated when cleaning form
    (ensures consistent formatting in the email)
  * Update/add tests to check contents of notification emails