### PR TITLE
Add doc name to anchors in document ballot popup

### DIFF
--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -22,6 +22,7 @@ from django.urls import reverse as urlreverse
 from django.conf import settings
 from django.forms import Form
 from django.utils.html import escape
+from django.utils.text import slugify
 
 from tastypie.test import ResourceTestCaseMixin
 
@@ -1547,6 +1548,52 @@ class DocTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(r, pos2.comment)
         self.assertContains(r,  '(was %s)' % pos.pos)
+
+    def test_document_ballot_popup_unique_anchors_per_doc(self):
+        """Ballot popup anchors should be different for each document"""
+        ad = Person.objects.get(user__username="ad")
+        docs = IndividualDraftFactory.create_batch(2)
+        ballots = [create_ballot_if_not_open(None, doc, ad, 'approve') for doc in docs]
+        for doc, ballot in zip(docs, ballots):
+            BallotPositionDocEvent.objects.create(
+                doc=doc,
+                rev=doc.rev,
+                ballot=ballot,
+                type="changed_ballot_position",
+                pos_id="yes",
+                comment="Looks fine to me",
+                comment_time=datetime.datetime.now(),
+                balloter=Person.objects.get(user__username="ad"),
+                by=Person.objects.get(name="(System)"))
+
+        anchors = set()
+        for doc, ballot in zip(docs, ballots):
+            BallotPositionDocEvent.objects.create(
+                doc=doc,
+                rev=doc.rev,
+                ballot=ballot,
+                type="changed_ballot_position",
+                pos_id="yes",
+                comment="Looks fine to me",
+                comment_time=datetime.datetime.now(),
+                balloter=Person.objects.get(user__username="ad"),
+                by=Person.objects.get(name="(System)"))
+
+            r = self.client.get(urlreverse(
+                "ietf.doc.views_doc.ballot_popup",
+                kwargs=dict(name=doc.name, ballot_id=ballot.pk)
+            ))
+            self.assertEqual(r.status_code, 200)
+            q = PyQuery(r.content)
+            href = q('div.balloter-name a').attr('href')
+            ids = [
+                target.attr('id')
+                for target in q('h4.anchor-target[id$="{}"]'.format(slugify(ad.plain_name()))).items()
+            ]
+            self.assertEqual(len(ids), 1, 'Should be exactly one link for the balloter')
+            self.assertEqual(href, f'#{ids[0]}', 'Anchor href should match ID')
+            anchors.add(href)
+        self.assertEqual(len(anchors), len(docs), 'Each doc should have a distinct anchor for the balloter')
 
     def test_document_ballot_needed_positions(self):
         # draft

--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -1567,28 +1567,18 @@ class DocTestCase(TestCase):
                 by=Person.objects.get(name="(System)"))
 
         anchors = set()
+        author_slug = slugify(ad.plain_name())
         for doc, ballot in zip(docs, ballots):
-            BallotPositionDocEvent.objects.create(
-                doc=doc,
-                rev=doc.rev,
-                ballot=ballot,
-                type="changed_ballot_position",
-                pos_id="yes",
-                comment="Looks fine to me",
-                comment_time=datetime.datetime.now(),
-                balloter=Person.objects.get(user__username="ad"),
-                by=Person.objects.get(name="(System)"))
-
             r = self.client.get(urlreverse(
                 "ietf.doc.views_doc.ballot_popup",
                 kwargs=dict(name=doc.name, ballot_id=ballot.pk)
             ))
             self.assertEqual(r.status_code, 200)
             q = PyQuery(r.content)
-            href = q('div.balloter-name a').attr('href')
+            href = q(f'div.balloter-name a[href$="{author_slug}"]').attr('href')
             ids = [
                 target.attr('id')
-                for target in q('h4.anchor-target[id$="{}"]'.format(slugify(ad.plain_name()))).items()
+                for target in q(f'h4.anchor-target[id$="{author_slug}"]').items()
             ]
             self.assertEqual(len(ids), 1, 'Should be exactly one link for the balloter')
             self.assertEqual(href, f'#{ids[0]}', 'Anchor href should match ID')

--- a/ietf/templates/doc/document_ballot_content.html
+++ b/ietf/templates/doc/document_ballot_content.html
@@ -9,7 +9,7 @@
       <h4><span class="label label-{{ n|pos_to_label }}"> {{ n.name }}</span></h4>
       {% for p in positions %}
         <div class="balloter-name">
-          {% if p.is_old_pos %}<span class="text-muted">({% endif %}{% if p.comment or p.discuss %}<a href="#{{ p.balloter.plain_name|slugify }}">{% endif %}{{ p.balloter.plain_name }}{% if p.comment or p.discuss %}</a>{% endif %}{% if p.is_old_pos %})</span>{% endif %}
+          {% if p.is_old_pos %}<span class="text-muted">({% endif %}{% if p.comment or p.discuss %}<a href="#{{ doc.name|slugify }}_{{ p.balloter.plain_name|slugify }}">{% endif %}{{ p.balloter.plain_name }}{% if p.comment or p.discuss %}</a>{% endif %}{% if p.is_old_pos %})</span>{% endif %}
         </div>
       {% empty %}
         (None)
@@ -73,7 +73,7 @@
     {% for n, positions in position_groups %}
       {% for p in positions %}
         {% if not p.is_old_pos %}
-          <h4 class="anchor-target" id="{{ p.balloter.plain_name|slugify }}">{{ p.balloter.plain_name }}
+          <h4 class="anchor-target" id="{{ doc.name|slugify }}_{{ p.balloter.plain_name|slugify }}">{{ p.balloter.plain_name }}
             <span class="pull-right">
             {% if p.old_positions %}<span class="text-muted small">(was {{ p.old_positions|join:", " }})</span>{% endif %}
             <span class="label label-{{ p.pos|pos_to_label }}">{{p.pos}}</span>
@@ -126,7 +126,7 @@
     {% for n, positions in position_groups %}
       {% for p in positions %}
         {% if p.is_old_pos %}
-          <h4 class="anchor-target" id="{{ p.balloter.plain_name|slugify }}">
+          <h4 class="anchor-target" id="{{ doc.name|slugify }}_{{ p.balloter.plain_name|slugify }}">
             <span class="text-muted">({{ p.balloter.plain_name }}; former steering group member)</span>
             <span class="pull-right">
               {% if p.old_positions %}<span class="text-muted small">(was {{ p.old_positions|join:", " }})</span>{% endif %}


### PR DESCRIPTION
Addresses [ticket 3351](https://trac.ietf.org/trac/ietfdb/ticket/3351) by prepending the document name to the anchor for each balloter's comments. Without this, opening more than one ballot pop-up winds up creating conflicting IDs on the IESG agenda/document page, breaking the links.