### PR TITLE
Allow empty-ish JSON values in group.GroupFeatures

### DIFF
--- a/ietf/group/models.py
+++ b/ietf/group/models.py
@@ -23,6 +23,7 @@ import debug                            # pyflakes:ignore
 from ietf.group.colors import fg_group_colors, bg_group_colors
 from ietf.name.models import GroupStateName, GroupTypeName, DocTagName, GroupMilestoneStateName, RoleName, AgendaTypeName, ExtResourceName
 from ietf.person.models import Email, Person
+from ietf.utils.db import IETFJSONField
 from ietf.utils.mail import formataddr, send_mail_text
 from ietf.utils import log
 from ietf.utils.models import ForeignKey, OneToOneField
@@ -282,14 +283,14 @@ class GroupFeatures(models.Model):
     agenda_type             = models.ForeignKey(AgendaTypeName, null=True, default="ietf", on_delete=CASCADE)
     about_page              = models.CharField(max_length=64, blank=False, default="ietf.group.views.group_about" )
     default_tab             = models.CharField(max_length=64, blank=False, default="ietf.group.views.group_about" )
-    material_types          = jsonfield.JSONField(max_length=64, blank=False, default=["slides"])
-    default_used_roles      = jsonfield.JSONField(max_length=256, blank=False, default=[])
-    admin_roles             = jsonfield.JSONField(max_length=64, blank=False, default=["chair"]) # Trac Admin
-    docman_roles            = jsonfield.JSONField(max_length=128, blank=False, default=["ad","chair","delegate","secr"])
-    groupman_roles          = jsonfield.JSONField(max_length=128, blank=False, default=["ad","chair",])
-    groupman_authroles      = jsonfield.JSONField(max_length=128, blank=False, default=["Secretariat",])
-    matman_roles            = jsonfield.JSONField(max_length=128, blank=False, default=["ad","chair","delegate","secr"])
-    role_order              = jsonfield.JSONField(max_length=128, blank=False, default=["chair","secr","member"],
+    material_types          = IETFJSONField(max_length=64, allowed_empty_values=[[], {}], blank=False, default=["slides"])
+    default_used_roles      = IETFJSONField(max_length=256, allowed_empty_values=[[], {}], blank=False, default=[])
+    admin_roles             = IETFJSONField(max_length=64, allowed_empty_values=[[], {}], blank=False, default=["chair"]) # Trac Admin
+    docman_roles            = IETFJSONField(max_length=128, allowed_empty_values=[[], {}], blank=False, default=["ad","chair","delegate","secr"])
+    groupman_roles          = IETFJSONField(max_length=128, allowed_empty_values=[[], {}], blank=False, default=["ad","chair",])
+    groupman_authroles      = IETFJSONField(max_length=128, allowed_empty_values=[[], {}], blank=False, default=["Secretariat",])
+    matman_roles            = IETFJSONField(max_length=128, allowed_empty_values=[[], {}], blank=False, default=["ad","chair","delegate","secr"])
+    role_order              = IETFJSONField(max_length=128, allowed_empty_values=[[], {}], blank=False, default=["chair","secr","member"],
                                                 help_text="The order in which roles are shown, for instance on photo pages.  Enter valid JSON.")
 
 

--- a/ietf/utils/db.py
+++ b/ietf/utils/db.py
@@ -1,0 +1,27 @@
+# Copyright The IETF Trust 2021, All Rights Reserved
+# -*- coding: utf-8 -*-
+
+# Taken from/inspired by
+# https://stackoverflow.com/questions/55147169/django-admin-jsonfield-default-empty-dict-wont-save-in-admin
+# 
+# JSONField should recognize {}, (), and [] as valid, non-empty JSON
+# values.  However, the base Field class excludes them
+import jsonfield
+from django.forms import fields
+
+from ietf.utils.fields import IETFJSONField
+
+
+class IETFJSONField(jsonfield.JSONField):
+    form_class = IETFJSONField
+    
+    def __init__(self, *args, empty_values=fields.CharField.empty_values, allowed_empty_values=[], **kwargs):
+        self.empty_values = [x
+                        for x in empty_values
+                        if x not in allowed_empty_values]
+        super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        if issubclass(kwargs['form_class'], IETFJSONField):
+            kwargs.setdefault('empty_values', self.empty_values)
+        return super().formfield(**{**kwargs})

--- a/ietf/utils/fields.py
+++ b/ietf/utils/fields.py
@@ -6,6 +6,9 @@ import datetime
 import json
 import re
 
+import jsonfield
+from django.forms import fields
+
 import debug                            # pyflakes:ignore
 
 from typing import Optional, Type # pyflakes:ignore
@@ -264,3 +267,13 @@ class SearchableField(forms.CharField):
             ))
 
         return objs.first() if self.max_entries == 1 else objs
+
+
+class IETFJSONField(jsonfield.fields.forms.JSONField):
+    def __init__(self, *args, empty_values=fields.CharField.empty_values,
+                 accepted_empty_values=[], **kwargs):
+        self.empty_values = [x
+                             for x in empty_values
+                             if x not in accepted_empty_values]
+
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
The JSONField object inherits empty_values from django's base Field class, which defines it as `[ None, '', {}, [], () ]`.  However, an entered JSON string of '[]' or '{}' will be interpreted as `[]` or `{}`, respectively, which will cause it to be evaluated as empty, which causes it to fail its validation for `required`, which is added when the field is defined as `blank=False`.

This change set allows a developer to control what JSON will be considered blank/empty.