### PR TITLE
Use live_server_url as IDTRACKER_BASE_URL in IetfLiveServerTestCase

### DIFF
--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -35,7 +35,7 @@ from ietf.meeting.utils import add_event_info_to_session_qs
 from ietf.utils.test_utils import assert_ical_response_is_valid
 from ietf.utils.jstest import ( IetfSeleniumTestCase, ifSeleniumEnabled, selenium_enabled,
                                 presence_of_element_child_by_css_selector )
-from ietf import settings
+from django.conf import settings
 
 if selenium_enabled():
     from selenium.webdriver.common.action_chains import ActionChains

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -800,10 +800,17 @@ class IetfLiveServerTestCase(StaticLiveServerTestCase):
         from ietf.person.models import Person
         if not Person.objects.exists():
             load_and_run_fixtures(verbosity=0)
+        self.replaced_settings = dict()
+        if hasattr(settings, 'IDTRACKER_BASE_URL'):
+            self.replaced_settings['IDTRACKER_BASE_URL'] = settings.IDTRACKER_BASE_URL
+            settings.IDTRACKER_BASE_URL = self.live_server_url
 
     @classmethod
     def tearDownClass(cls):
         super(IetfLiveServerTestCase, cls).tearDownClass()
         set_coverage_checking(True)
 
-    
+    def tearDown(self):
+        for k, v in self.replaced_settings.items():
+            setattr(settings, k, v)
+        super().tearDown()


### PR DESCRIPTION
Addresses [ticket 3203](https://trac.ietf.org/trac/ietfdb/ticket/3203).

The problem encountered in the ticket resulted from JS making xhr requests to relative URLs computed by `Document.get_href()`. I don't understand exactly how that is ending up relative to the `IDTRACKER_BASE_URL`, but it seems like the correct behavior.

An alternative approach is to override the `MEETING_DOC_*REF` settings to be absolute URLs. That is more tailored to the problem here, but I can't think of any reason why we would want to be pointing to the `IDTRACKER_BASE_URL` from `settings.py` or `settings_local.py` while using the live server. This more general replacement is more likely to prevent future request leakage.