### PR TITLE
Handle missing 'to' field in process_response_email

### DIFF
--- a/ietf/ipr/mail.py
+++ b/ietf/ipr/mail.py
@@ -175,8 +175,8 @@ def process_response_email(msg):
     IprEvent.  Create a Message object for the incoming message and associate it to
     the original message via new IprEvent"""
     message = email.message_from_string(force_str(msg))
-    to = message.get('To')
-    
+    to = message.get('To', '')
+
     # exit if this isn't a response we're interested in (with plus addressing)
     local,domain = get_base_ipr_request_address().split('@')
     if not re.match(r'^{}\+[a-zA-Z0-9_\-]{}@{}'.format(local,'{16}',domain),to):

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -632,16 +632,26 @@ I would like to revoke this declaration.
         self.assertEqual(len(outbox), 1)
         self.assertTrue('joe@test.com' in outbox[0]['To'])
         
-        # test process response uninteresting message
+        # test process response uninteresting messages
         addrs = gather_address_lists('ipr_disclosure_submitted').as_strings()
-        message_string = """To: {}
-Cc: {}
-From: joe@test.com
-Date: {}
-Subject: test
-""".format(addrs.to, addrs.cc, datetime.datetime.now().ctime())
-        result = process_response_email(message_string)
-        self.assertIsNone(result)
+        uninteresting_message_strings = [
+            ("To: {to}\nCc: {cc}\nFrom: joe@test.com\nDate: {date}\nSubject: test\n"),
+            ("Cc: {cc}\nFrom: joe@test.com\nDate: {date}\nSubject: test\n"),  # no To
+            ("To: {to}\nFrom: joe@test.com\nDate: {date}\nSubject: test\n"),  # no Cc
+            ("From: joe@test.com\nDate: {date}\nSubject: test\n"),  # no To or Cc
+            ("Cc: {cc}\nDate: {date}\nSubject: test\n"),  # no To
+            ("To: {to}\nDate: {date}\nSubject: test\n"),  # no Cc
+            ("Date: {date}\nSubject: test\n"),  # no To or Cc
+        ]
+        for message_string in uninteresting_message_strings:
+            result = process_response_email(
+                message_string.format(
+                    to=addrs.to,
+                    cc=addrs.cc,
+                    date=datetime.datetime.now().ctime()
+                )
+            )
+            self.assertIsNone(result)
         
         # test process response
         message_string = """To: {}


### PR DESCRIPTION
Related to [ticket 3357](https://trac.ietf.org/trac/ietfdb/ticket/3357). Trivial change plus a tweaked test.