### PR TITLE
Allow pre-ADs to be assigned as a document's responsible AD

### DIFF
--- a/ietf/doc/views_draft.py
+++ b/ietf/doc/views_draft.py
@@ -1111,8 +1111,16 @@ def change_shepherd_email(request, name):
     })
 
 class AdForm(forms.Form):
-    ad = forms.ModelChoiceField(Person.objects.filter(role__name="ad", role__group__state="active", role__group__type="area").order_by('name'), 
-                                label="Shepherding AD", empty_label="(None)", required=False)
+    ad = forms.ModelChoiceField(
+        Person.objects.filter(
+            role__name__in=("ad", "pre-ad"),
+            role__group__state="active",
+            role__group__type="area",
+        ).order_by('name'),
+        label="Shepherding AD",
+        empty_label="(None)",
+        required=False,
+    )
 
     def __init__(self, doc, *args, **kwargs):
         super(self.__class__, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Addresses [ticket 3229](https://trac.ietf.org/trac/ietfdb/ticket/3229). Fixes #34 

From emails with the IESG, pre-ADs already have at least most of the privileges they need except for being able to be assigned as responsible for a document. This is needed to ease transition between ADs.