### PR TITLE
Correctly highlight session constraints in the meeting schedule editor

### DIFF
--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -26,6 +26,7 @@ jQuery(document).ready(function () {
     }
 
     let sessions = content.find(".session").not(".readonly");
+    let sessionConstraints = sessions.find('.constraints > span');
     let timeslots = content.find(".timeslot");
     let timeslotLabels = content.find(".time-label");
     let swapDaysButtons = content.find('.swap-days');
@@ -154,23 +155,24 @@ jQuery(document).ready(function () {
         timeslotLabels.removeClass("would-violate-hint");
     }
 
+    /**
+     * Remove all would-violate-hint classes on sessions and their formatted constraints
+     */
+    function resetSessionsWouldViolate() {
+        sessions.removeClass("would-violate-hint");
+        sessionConstraints.removeClass("would-violate-hint");
+    }
+
     function showConstraintHints(selectedSession) {
         let sessionId = selectedSession ? selectedSession.id.slice("session".length) : null;
         // hints on the sessions
-        sessions.find(".constraints > span").each(function () {
-            let wouldViolate = false;
-            let applyChange = true;
+        resetSessionsWouldViolate();
+        sessionConstraints.each(function () {
             if (sessionId) {
                 let sessionIds = this.dataset.sessions;
-                if (!sessionIds) {
-                    applyChange = false;
-                } else {
-                    wouldViolate = sessionIds.split(",").indexOf(sessionId) !== -1;
+                if (sessionIds && (sessionIds.split(",").indexOf(sessionId) !== -1)) {
+                    setSessionWouldViolate(this, true);
                 }
-            }
-
-            if (applyChange) {
-                setSessionWouldViolate(this, wouldViolate);
             }
         });
 

--- a/ietf/static/ietf/js/edit-meeting-schedule.js
+++ b/ietf/static/ietf/js/edit-meeting-schedule.js
@@ -167,14 +167,14 @@ jQuery(document).ready(function () {
         let sessionId = selectedSession ? selectedSession.id.slice("session".length) : null;
         // hints on the sessions
         resetSessionsWouldViolate();
-        sessionConstraints.each(function () {
-            if (sessionId) {
+        if (sessionId) {
+            sessionConstraints.each(function () {
                 let sessionIds = this.dataset.sessions;
                 if (sessionIds && (sessionIds.split(",").indexOf(sessionId) !== -1)) {
                     setSessionWouldViolate(this, true);
                 }
-            }
-        });
+            });
+        }
 
         // hints on timeslots
         resetTimeslotsWouldViolate();


### PR DESCRIPTION
Addresses [ticket 3327](https://trac.ietf.org/trac/ietfdb/ticket/3327). In the meeting schedule editor, sessions in conflict with the selected session were frequently (but somewhat randomly) not highlighted.

The issue arose because each constraint in a session set or cleared the highlighted status independently. The result was that the last to set it "won". The result was wildly and unpredictably wrong. I think the original purpose of the `applyChange` flag may have been to fix this, but if so it was a fragile (and forgotten) approach. This fix simplifies the algorithm to: clear all the highlights, then mark any detected conflicts as highlighted. That removes the possibility of a non-violated constraint clearing the highlighted state.