### PR TITLE
Refactor agenda.html using custom template tags

### DIFF
--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -26,6 +26,7 @@ from django.conf import settings
 # mostly used by json_dict()
 #from django.template.defaultfilters import slugify, date as date_format, time as time_format
 from django.template.defaultfilters import date as date_format
+from django.urls import reverse as urlreverse
 from django.utils.text import slugify
 from django.utils.safestring import mark_safe
 
@@ -487,6 +488,18 @@ class Room(models.Model):
             'capacity':             self.capacity,
             }
     # floorplan support
+    def floorplan_url(self):
+        mtg_num = self.meeting.get_number()
+        if not mtg_num:
+            return None
+        elif mtg_num <= settings.FLOORPLAN_LAST_LEGACY_MEETING:
+            base_url = settings.FLOORPLAN_LEGACY_BASE_URL.format(meeting=self.meeting)
+        elif self.floorplan:
+            base_url = urlreverse('ietf.meeting.views.floor_plan', kwargs=dict(num=mtg_num))
+        else:
+            return None
+        return f'{base_url}?room={xslugify(self.name)}'
+
     def left(self):
         return min(self.x1, self.x2) if (self.x1 and self.x2) else 0
     def top(self):

--- a/ietf/meeting/templatetags/agenda_custom_tags.py
+++ b/ietf/meeting/templatetags/agenda_custom_tags.py
@@ -5,6 +5,8 @@
 from django import template
 from django.urls import reverse
 
+from ietf.utils.text import xslugify
+
 register = template.Library()
 
 
@@ -68,3 +70,85 @@ def webcal_url(context, viewname, *args, **kwargs):
         context.request.get_host(),
         reverse(viewname, args=args, kwargs=kwargs)
     )
+
+@register.simple_tag
+def assignment_display_name(assignment):
+    """Get name for an assignment"""
+    if assignment.slot_type().slug == 'regular' and assignment.session.historic_group:
+        return assignment.session.historic_group.name
+    return assignment.timeslot.name
+
+
+class AnchorNode(template.Node):
+    """Template node for a conditionally-included anchor
+
+    If self.resolve_url() returns a URL, the contents of the nodelist will be rendered inside
+    <a href="{{ self.resolve_url() }}"> ... </a>. If it returns None, the <a> will be omitted.
+    The contents will be rendered in either case.
+    """
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def resolve_url(self, context):
+        raise NotImplementedError('Subclasses must define this method')
+
+    def render(self, context):
+        url = self.resolve_url(context)
+        if url:
+            return '<a href="{}">{}</a>'.format(url, self.nodelist.render(context))
+        else:
+            return self.nodelist.render(context)
+
+
+class AgendaAnchorNode(AnchorNode):
+    """Template node for the agenda_anchor tag"""
+    def __init__(self, session, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = template.Variable(session)
+
+    def resolve_url(self, context):
+        sess = self.session.resolve(context)
+        agenda = sess.agenda()
+        if agenda:
+            return agenda.get_href()
+        return None
+
+
+@register.tag
+def agenda_anchor(parser, token):
+    """Block tag that wraps its content in a link to the session agenda, if any"""
+    try:
+        tag_name, sess_var = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError('agenda_anchor requires a single argument')
+    nodelist = parser.parse(('end_agenda_anchor',))
+    parser.delete_first_token()  # delete the end tag
+    return AgendaAnchorNode(sess_var, nodelist)
+
+
+class LocationAnchorNode(AnchorNode):
+    """Template node for the location_anchor tag"""
+    def __init__(self, timeslot, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.timeslot = template.Variable(timeslot)
+
+    def resolve_url(self, context):
+        ts = self.timeslot.resolve(context)
+        if ts.show_location and ts.location:
+            return ts.location.floorplan_url()
+        return None
+
+@register.tag
+def location_anchor(parser, token):
+    """Block tag that wraps its content in a link to the timeslot location
+
+    If the timeslot has no location information or is marked with show_location=False,
+    the anchor tag is omitted.
+    """
+    try:
+        tag_name, ts_var = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError('location_anchor requires a single argument')
+    nodelist = parser.parse(('end_location_anchor',))
+    parser.delete_first_token()  # delete the end tag
+    return LocationAnchorNode(ts_var, nodelist)

--- a/ietf/meeting/templatetags/tests.py
+++ b/ietf/meeting/templatetags/tests.py
@@ -1,0 +1,20 @@
+# Copyright The IETF Trust 2009-2020, All Rights Reserved
+# -*- coding: utf-8 -*-
+
+from ietf.meeting.templatetags.agenda_custom_tags import AnchorNode
+from ietf.utils.test_utils import TestCase
+
+
+class AgendaCustomTagsTests(TestCase):
+    def test_anchor_node_subclasses_implement_resolve_url(self):
+        """Check that AnchorNode subclasses implement the resolve_url method
+
+        This will only catch errors in subclasses defined in the agenda_custom_tags.py module.
+        """
+        for subclass in AnchorNode.__subclasses__():
+            try:
+                subclass.resolve_url(None, None)
+            except NotImplementedError:
+                self.fail(f'{subclass.__name__} must implement resolve_url() method')
+            except:
+                pass  # any other failure ok since we used garbage inputs

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -959,6 +959,8 @@ INTERNET_DRAFT_DAYS_TO_EXPIRE = 185
 
 FLOORPLAN_MEDIA_DIR = 'floor'
 FLOORPLAN_DIR = os.path.join(MEDIA_ROOT, FLOORPLAN_MEDIA_DIR)
+FLOORPLAN_LEGACY_BASE_URL = 'https://tools.ietf.org/agenda/{meeting.number}/venue/'
+FLOORPLAN_LAST_LEGACY_MEETING = 95  # last meeting to use FLOORPLAN_LEGACY_BASE_URL
 
 MEETING_USES_CODIMD_DATE = datetime.date(2020,7,6)
 MEETING_LEGACY_OFFICE_HOURS_END = 111  # last meeting to use legacy office hours representation

--- a/ietf/templates/meeting/agenda.html
+++ b/ietf/templates/meeting/agenda.html
@@ -4,7 +4,7 @@
 {% load static %}
 {% load ietf_filters %}
 {% load textfilters %}
-{% load htmlfilters %}
+{% load htmlfilters agenda_custom_tags%}
 
 {% block title %}
   IETF {{ schedule.meeting.number }} meeting agenda
@@ -154,35 +154,27 @@
                     </span>
                       </td>
                       <td colspan="3">
-                    <span class="hidden-sm hidden-md hidden-lg">
-                       {% include "meeting/timeslot_start_end.html" %}
-                    </span>
-                          {% if item.timeslot.show_location and item.timeslot.get_html_location %}
-                              {% if schedule.meeting.number|add:"0" < 96 %}
-                                  <a href="https://tools.ietf.org/agenda/{{schedule.meeting.number}}/venue/?room={{ item.timeslot.get_html_location|xslugify }}">{{item.timeslot.get_html_location}}</a>
-                              {% elif item.timeslot.location.floorplan %}
-                                  <a href="{% url 'ietf.meeting.views.floor_plan' num=schedule.meeting.number %}?room={{ item.timeslot.get_html_location|xslugify }}">{{item.timeslot.get_html_location}}</a>
-                              {% else %}
-                                  {{item.timeslot.get_html_location}}
-                              {% endif %}
-                              {% with item.timeslot.location.floorplan as floor %}
-                                  {% if item.timeslot.location.floorplan %}
-                                      <span class="hidden-xs">
-			<a href="{% url 'ietf.meeting.views.floor_plan' num=schedule.meeting.number %}#{{floor.name|xslugify}}"
-               class="pull-right" title="{{floor.name}}"><span class="label label-blank label-wide">{{floor.short}}</span></a>
-                      </span>
-                                  {% endif %}
-                              {% endwith %}
-                          {% endif %}
+                        <span class="hidden-sm hidden-md hidden-lg">
+                           {% include "meeting/timeslot_start_end.html" %}
+                        </span>
+                        {% location_anchor item.timeslot %}
+                          {{ item.timeslot.get_html_location }}
+                        {% end_location_anchor %}
+                        {% if item.timeslot.show_location and item.timeslot.get_html_location %}
+                          {% with item.timeslot.location.floorplan as floor %}
+                            {% if item.timeslot.location.floorplan %}
+                              <span class="hidden-xs">
+                                <a href="{% url 'ietf.meeting.views.floor_plan' num=schedule.meeting.number %}#{{floor.name|xslugify}}"
+                                   class="pull-right" title="{{floor.name}}"><span class="label label-blank label-wide">{{floor.short}}</span></a>
+                              </span>
+                            {% endif %}
+                          {% endwith %}
+                        {% endif %}
                       </td>
                       <td>
-                          {% if item.session.agenda %}
-                              <a href="{{ item.session.agenda.get_href }}">
-                                  {{item.timeslot.name}}
-                              </a>
-                          {% else %}
-                              {{item.timeslot.name}}
-                          {% endif %}
+                          {% agenda_anchor item.session %}
+                            {% assignment_display_name item %}
+                          {% end_agenda_anchor %}
 
                           {% if item.session.current_status == 'canceled' %}
                               <span class="label label-danger pull-right">CANCELLED</span>
@@ -230,7 +222,7 @@
                 {% endif %}
 
               {% if item.session.historic_group %}
-                <tr id="row-{{item.slug}}" 
+                <tr id="row-{{item.slug}}"
                     {% if item.slot_type.slug == 'plenary' %}class="{{item.slot_type.slug}}danger"{% endif %}
                     data-filter-keywords="{{ item.filter_keywords|join:',' }}"
                     data-slot-start-ts="{{item.start_timestamp}}"
@@ -242,20 +234,14 @@
                          {% include "meeting/timeslot_start_end.html" %}
                       </span>
 		    </th>
-		    <td colspan="3">
+        <td colspan="3">
                       <span class="hidden-sm hidden-md hidden-lg">
                          {% include "meeting/timeslot_start_end.html" %}
                       </span>
-		      {% if item.timeslot.show_location and item.timeslot.get_html_location %}
-			{% if schedule.meeting.number|add:"0" < 96 %}
-			<a href="https://tools.ietf.org/agenda/{{schedule.meeting.number}}/venue/?room={{ item.timeslot.get_html_location|xslugify }}">{{item.timeslot.get_html_location}}</a>
-                        {% elif item.timeslot.location.floorplan %}
-			<a href="{% url 'ietf.meeting.views.floor_plan' num=schedule.meeting.number %}?room={{ item.timeslot.get_html_location|xslugify }}">{{item.timeslot.get_html_location}}</a>
-			{% else %}
-                        {{item.timeslot.get_html_location}}
-			{% endif %}
-		      {% endif %}
-		    </td>
+          {% location_anchor item.timeslot %}
+            {{ item.timeslot.get_html_location }}
+          {% end_location_anchor %}
+        </td>
 
 		  {% else %}
 		    <td>
@@ -269,15 +255,9 @@
 		      {% endwith %}
 		    </td>
                     <td>
-                      {% if item.timeslot.show_location and item.timeslot.get_html_location %}
-			{% if schedule.meeting.number|add:"0" < 96 %}
-			<a href="https://tools.ietf.org/agenda/{{schedule.meeting.number}}/venue/?room={{ item.timeslot.get_html_location|xslugify }}">{{item.timeslot.get_html_location}}</a>
-                        {% elif item.timeslot.location.floorplan %}
-			<a href="{% url 'ietf.meeting.views.floor_plan' num=schedule.meeting.number %}?room={{ item.timeslot.get_html_location|xslugify }}">{{item.timeslot.get_html_location}}</a>
-                        {% else %}
-                        {{item.timeslot.get_html_location}}
-			{% endif %}
-                      {% endif %}
+                      {% location_anchor item.timeslot %}
+                        {{ item.timeslot.get_html_location }}
+                      {% end_location_anchor %}
                     </td>
 
 		      <td><span class="hidden-xs">{{item.session.historic_group.historic_parent.acronym}}</span></td>
@@ -292,18 +272,9 @@
                   {% endif %}
 
                   <td>
-                    {% if item.session.agenda %}
-		      <a href="{{ item.session.agenda.get_href }}">
-                    {% endif %}
-                    {% if item.slot_type.slug == 'plenary' %}
-                      {{item.timeslot.name}}
-                    {% else %}
-                      {{item.session.historic_group.name}}
-                    {% endif %}
-                    {% if item.session.agenda %}
-                      </a>
-                    {% endif %}
-
+                    {% agenda_anchor item.session %}
+                        {% assignment_display_name item %}
+                    {% end_agenda_anchor %}
                     {% if item.session.current_status == 'canceled' %}
                       <span class="label label-danger pull-right">CANCELLED</span>
                     {% else %}
@@ -453,9 +424,9 @@
                // either have not yet loaded the iframe or we do not support history replacement
                wv_iframe.src = new_url;
            }
-       }       
+       }
    }
-   
+
    function update_view(filter_params) {
        update_agenda_display(filter_params);
        update_weekview(filter_params)


### PR DESCRIPTION
This (slightly) improves the agenda.html template by using custom tags to eliminate some of the needlessly repeated code. The tags are responsible for determining the display name of a SchedTimeSessAssignment and for linking to a session agenda or timeslot location if they exist.

This is a first piece of fixing ticket 3330 - the goal here is to move the place where assignment names are determined into a single place.

The best location for the logic in the new tags is a little unclear. I've moved the responsibility for generating a floorplan URL into the `Room` model, which seems straightforward. Deciding when and whether to link to that URL seems more like a template-level issue. I contemplated adding a `TimeSlot.floorplan_url()` method, but that seems like a road to duplicating the entire `Room` api on the `TimeSlot` model.

The session agenda already has a `get_href()` method, so I just used that.

The other new tag is the `assignment_display_name` tag. This begs to be on the `SchedTimeSessAssignment` model, except that it uses the `historic_group` machinery that is in the view. It's used a few places in `meeting/models.py` already, but that seems like a bug rather than a feature unless we aim to move the calculation of the historic group over that way.