### PR TITLE
Add timeslot editor better integrated with the new meeting schedule editor

### DIFF
--- a/ietf/meeting/factories.py
+++ b/ietf/meeting/factories.py
@@ -37,6 +37,10 @@ class MeetingFactory(factory.django.DjangoModelFactory):
     break_area = factory.Faker('sentence')
     reg_area = factory.Faker('sentence')
 
+    # Inform typing system that MeetingFactory() produces a model instance
+    def __new__(cls, *args, **kwargs) -> Meta.model:
+        return super().__new__(*args, **kwargs)
+
     @factory.lazy_attribute_sequence
     def number(self,n):
         if self.type_id == 'ietf':

--- a/ietf/meeting/factories.py
+++ b/ietf/meeting/factories.py
@@ -37,10 +37,6 @@ class MeetingFactory(factory.django.DjangoModelFactory):
     break_area = factory.Faker('sentence')
     reg_area = factory.Faker('sentence')
 
-    # Inform typing system that MeetingFactory() produces a model instance
-    def __new__(cls, *args, **kwargs) -> Meta.model:
-        return super().__new__(*args, **kwargs)
-
     @factory.lazy_attribute_sequence
     def number(self,n):
         if self.type_id == 'ietf':

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -338,6 +338,13 @@ class Meeting(models.Model):
             }
 
     def build_timeslices(self):
+        """Get unique day/time/timeslot data for meeting
+        
+        Returns a list of days, time intervals for each day, and timeslots for each day,
+        with repeated days/time intervals removed. Ignores timeslots that do not have a
+        location. The slots return value contains only one TimeSlot for each distinct
+        time interval.
+        """
         days = []          # the days of the meetings
         time_slices = {}   # the times on each day
         slots = {}
@@ -359,8 +366,9 @@ class Meeting(models.Model):
 
         days.sort()
         for ymd in time_slices:
+            # Make sure these sort the same way
             time_slices[ymd].sort()
-            slots[ymd].sort(key=lambda x: x.time)
+            slots[ymd].sort(key=lambda x: (x.time, x.duration))
         return days,time_slices,slots
 
     # this functions makes a list of timeslices and rooms, and

--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -2580,6 +2580,165 @@ class ProceedingsMaterialTests(IetfSeleniumTestCase):
                         'URL field should be shown by default')
 
 
+class EditTimeslotsTests(IetfSeleniumTestCase):
+    """Test the timeslot editor"""
+    def setUp(self):
+        super().setUp()
+        self.meeting: Meeting = MeetingFactory(
+            type_id='ietf',
+            number=120,
+            date=datetime.datetime.today() + datetime.timedelta(days=10),
+            populate_schedule=False,
+        )
+        self.edit_timeslot_url = self.absreverse(
+            'ietf.meeting.views.edit_timeslots',
+            kwargs=dict(num=self.meeting.number),
+        )
+        self.wait = WebDriverWait(self.driver, 2)
+
+    def do_delete_test(self, selector, keep, delete, cancel=False):
+        self.login('secretary')
+        self.driver.get(self.edit_timeslot_url)
+        delete_button = self.wait.until(
+            expected_conditions.element_to_be_clickable(
+                (By.CSS_SELECTOR, selector)
+            ))
+        delete_button.click()
+
+        if cancel:
+            cancel_button = self.wait.until(
+                expected_conditions.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '#delete-modal button[data-dismiss="modal"]')
+                ))
+            cancel_button.click()
+        else:
+            confirm_button = self.wait.until(
+                expected_conditions.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '#confirm-delete-button')
+                ))
+            confirm_button.click()
+
+        self.wait.until(
+            expected_conditions.invisibility_of_element_located(
+                (By.CSS_SELECTOR, '#delete-modal')
+            ))
+
+        if cancel:
+            keep.extend(delete)
+            delete = []
+
+        self.assertEqual(
+            TimeSlot.objects.filter(pk__in=[ts.pk for ts in delete]).count(),
+            0,
+            'Not all expected timeslots deleted',
+        )
+        self.assertEqual(
+            TimeSlot.objects.filter(pk__in=[ts.pk for ts in keep]).count(),
+            len(keep),
+            'Not all expected timeslots kept'
+        )
+
+    def do_delete_timeslot_test(self, cancel=False):
+        delete = [TimeSlotFactory(meeting=self.meeting)]
+        keep = [TimeSlotFactory(meeting=self.meeting)]
+
+        self.do_delete_test(
+            '#timeslot-table #timeslot{} .delete-button'.format(delete[0].pk),
+            keep,
+            delete
+        )
+
+    def test_delete_timeslot(self):
+        """Delete button for a timeslot should delete that timeslot"""
+        self.do_delete_timeslot_test(cancel=False)
+
+    def test_delete_timeslot_cancel(self):
+        """Timeslot should not be deleted on cancel"""
+        self.do_delete_timeslot_test(cancel=True)
+
+    def do_delete_time_interval_test(self, cancel=False):
+        delete_day = self.meeting.date.date()
+        delete_time = datetime.time(hour=10)
+        other_day = self.meeting.get_meeting_date(1).date()
+        other_time = datetime.time(hour=12)
+        duration = datetime.timedelta(minutes=60)
+
+        delete: [TimeSlot] = TimeSlotFactory.create_batch(
+            2,
+            meeting=self.meeting,
+            time=datetime.datetime.combine(delete_day, delete_time),
+            duration=duration)
+
+        keep: [TimeSlot] = [
+            TimeSlotFactory(
+                meeting=self.meeting,
+                time=datetime.datetime.combine(day, time),
+                duration=duration
+            )
+            for (day, time) in (
+                # combinations of day/time that should not be deleted
+                (delete_day, other_time),
+                (other_day, delete_time),
+                (other_day, other_time),
+            )
+        ]
+
+        selector = (
+            '#timeslot-table '
+            '.delete-button[data-delete-scope="column"]'
+            '[data-col-id="{}T{}-{}"]'.format(
+                delete_day.isoformat(),
+                delete_time.strftime('%H:%M'),
+                (datetime.datetime.combine(delete_day, delete_time) + duration).strftime(
+                    '%H:%M'
+                ))
+        )
+        self.do_delete_test(selector, keep, delete, cancel)
+
+    def test_delete_time_interval(self):
+        """Delete button for a time interval should delete all timeslots in that interval"""
+        self.do_delete_time_interval_test(cancel=False)
+
+    def test_delete_time_interval_cancel(self):
+        """Should not delete a time interval on cancel"""
+        self.do_delete_time_interval_test(cancel=True)
+
+    def do_delete_day_test(self, cancel=False):
+        delete_day = self.meeting.date.date()
+        times = [datetime.time(hour=10), datetime.time(hour=12)]
+        other_days = [self.meeting.get_meeting_date(d).date() for d in range(1, 3)]
+
+        delete: [TimeSlot] = [
+            TimeSlotFactory(
+                meeting=self.meeting,
+                time=datetime.datetime.combine(delete_day, time),
+            ) for time in times
+        ]
+
+        keep: [TimeSlot] = [
+            TimeSlotFactory(
+                meeting=self.meeting,
+                time=datetime.datetime.combine(day, time),
+            ) for day in other_days for time in times
+        ]
+
+        selector = (
+            '#timeslot-table '
+            '.delete-button[data-delete-scope="day"][data-date-id="{}"]'.format(
+                delete_day.isoformat()
+            )
+        )
+        self.do_delete_test(selector, keep, delete, cancel)
+
+    def test_delete_day(self):
+        """Delete button for a day should delete all timeslots on that day"""
+        self.do_delete_day_test(cancel=False)
+
+    def test_delete_day_cancel(self):
+        """Should not delete a day on cancel"""
+        self.do_delete_day_test(cancel=True)
+
+
 # The following are useful debugging tools
 
 # If you add this to a LiveServerTestCase and run just this test, you can browse

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1768,7 +1768,7 @@ class EditTimeslotsTests(TestCase):
         _assert_permissions('with schedule')  # then test with a meeting schedule
 
     def test_linked_from_agenda_list(self):
-        """The edit timeslots view be linked from the agenda list view"""
+        """The edit timeslots view should be linked from the agenda list view"""
         ad = RoleFactory(name_id='ad', group__type_id='area').person
 
         meeting = self.create_bare_meeting()

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1690,7 +1690,7 @@ class EditTimeslotsTests(TestCase):
         return urlreverse('ietf.meeting.views.create_timeslot', kwargs={'num': meeting.number})
 
     @staticmethod
-    def create_bare_meeting(number=120):
+    def create_bare_meeting(number=120) -> Meeting:
         """Create a basic IETF meeting"""
         return MeetingFactory(
             type_id='ietf',

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1859,7 +1859,6 @@ class EditTimeslotsTests(TestCase):
         self.create_initial_schedule(meeting)
         r = self.client.get(self.edit_timeslots_url(meeting))
         self.assertEqual(r.status_code, 200)
-        q = PyQuery(r.content)
         self.assert_helpful_url(r, helpful_url,
                                  'Must be a link to a helpful URL when there are no timeslots')
 
@@ -1997,12 +1996,18 @@ class EditTimeslotsTests(TestCase):
             TimeSlotFactory(
                 meeting=meeting,
                 location=meeting.room_set.first(),
-                time=meeting.get_meeting_date(day) + datetime.timedelta(hours=11),
+                time=datetime.datetime.combine(
+                    meeting.get_meeting_date(day).date(),
+                    datetime.time(hour=11)
+                ),
             )
             TimeSlotFactory(
                 meeting=meeting,
                 location=meeting.room_set.first(),
-                time=meeting.get_meeting_date(day) + datetime.timedelta(hours=14),
+                time=datetime.datetime.combine(
+                    meeting.get_meeting_date(day).date(),
+                    datetime.time(hour=14)
+                ),
             )
 
         self.login()

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1681,6 +1681,10 @@ class EditMeetingScheduleTests(TestCase):
 
 
 class EditTimeslotsTests(TestCase):
+    def login(self, username='secretary'):
+        """Log in with permission to edit timeslots"""
+        self.client.login(username=username, password='{}+password'.format(username))
+
     @staticmethod
     def edit_timeslots_url(meeting):
         return urlreverse('ietf.meeting.views.edit_timeslots', kwargs={'num': meeting.number})
@@ -1777,7 +1781,7 @@ class EditTimeslotsTests(TestCase):
         url = urlreverse('ietf.meeting.views.list_schedules', kwargs={'num': meeting.number})
 
         # Should have no link when logged in as area director
-        self.client.login(username=ad.user.username, password=ad.user.username + '+password')
+        self.login(ad.user.username)
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         q = PyQuery(r.content)
@@ -1788,7 +1792,7 @@ class EditTimeslotsTests(TestCase):
         )
 
         # Should have a link when logged in as secretary
-        self.client.login(username='secretary', password='secretary+password')
+        self.login()
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         q = PyQuery(r.content)
@@ -1809,7 +1813,7 @@ class EditTimeslotsTests(TestCase):
     def test_with_no_rooms(self):
         """Editor should be helpful when there are no rooms yet"""
         meeting = self.create_bare_meeting()
-        self.client.login(username='secretary', password='secretary+password')
+        self.login()
 
         # with no schedule, should get a link to the meeting page in the secr app until we can
         # handle this situation in the meeting app
@@ -1836,7 +1840,7 @@ class EditTimeslotsTests(TestCase):
         """Editor should be helpful when there are rooms but no timeslots yet"""
         meeting = self.create_bare_meeting()
         RoomFactory(meeting=meeting)
-        self.client.login(username='secretary', password='secretary+password')
+        self.login()
         helpful_url = self.create_timeslots_url(meeting)
 
         # with no schedule, should get a link to the meeting page in the secr app until we can
@@ -1877,11 +1881,396 @@ class EditTimeslotsTests(TestCase):
         self.create_initial_schedule(meeting)
         RoomFactory.create_batch(8, meeting=meeting)
 
-        self.client.login(username='secretary', password='secretary+password')
+        self.login()
         r = self.client.get(self.edit_timeslots_url(meeting))
         self.assertEqual(r.status_code, 200)
         self.assert_required_links_present(r, meeting)
 
+    def test_shows_timeslots(self):
+        """Timeslots should be displayed properly"""
+        def _col_index(elt):
+            """Find the column index of an element in its table row
+
+            First column is 1
+            """
+            selector = 'td, th'  # accept both td and th elements
+            col_elt = elt.closest(selector)
+            tr = col_elt.parent('tr')
+            return 1 + tr.children(selector).index(col_elt[0])  # [0] gets bare element
+
+        meeting = self.create_meeting()
+        # add some timeslots
+        times = [datetime.time(hour=h) for h in (11, 14)]
+        days = [meeting.get_meeting_date(ii).date() for ii in range(meeting.days)]
+
+        timeslots = []
+        duration = datetime.timedelta(minutes=90)
+        for room in meeting.room_set.all():
+            for day in days:
+                timeslots.extend(
+                    TimeSlotFactory(
+                        meeting=meeting,
+                        location=room,
+                        time=datetime.datetime.combine(day, t),
+                        duration=duration,
+                    )
+                    for t in times
+                )
+
+        # get the page under test
+        self.login()
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+
+        q = PyQuery(r.content)
+        table = q('#timeslot-table')
+        self.assertEqual(len(table), 1, 'Exactly one timeslot-table required')
+        table = table.eq(0)
+
+        # check the day super-column headings
+        day_headings = table.find('.day-label')
+        self.assertEqual(len(day_headings), len(days))
+        day_columns = dict()  # map datetime to iterable with table col indices for that day
+        next_col = _col_index(day_headings.eq(0))  # find column of the first day
+        for day, heading in zip(days, day_headings.items()):
+            self.assertIn(day.strftime('%a'), heading.text(),
+                          'Weekday abbrev for {} not found in heading'.format(day))
+            self.assertIn(day.strftime('%Y-%m-%d'), heading.text(),
+                          'Numeric date for {} not found in heading'.format(day))
+            cols = int(heading.attr('colspan'))  # columns spanned by day header
+            day_columns[day] = range(next_col, next_col + cols)
+            next_col += cols
+
+        # check the timeslot time headings
+        time_headings = table.find('.time-label')
+        self.assertEqual(len(time_headings), len(times) * len(days))
+
+        expected_columns = dict()  # [date][time] element is expected column for a timeslot
+        for day, columns in day_columns.items():
+            headings = time_headings.filter(
+                # selector for children in any of the day's columns
+                ','.join(
+                    ':nth-child({})'.format(col)
+                    for col in columns
+                )
+            )
+            expected_columns[day] = dict()
+            for time, heading in zip(times, headings.items()):
+                self.assertIn(time.strftime('%H:%M'), heading.text(),
+                              'Timeslot start {} not found for day {}'.format(time, day))
+                expected_columns[day][time] = _col_index(heading)
+
+        # check that the expected timeslots are shown with expected info / ui features
+        timeslot_elts = table.find('.timeslot')
+        self.assertEqual(len(timeslot_elts), len(timeslots), 'Unexpected or missing timeslot elements')
+        for ts in timeslots:
+            pk_elts = timeslot_elts.filter('#timeslot{}'.format(ts.pk))
+            self.assertEqual(len(pk_elts), 1, 'Expect exactly one element for each timeslot')
+            elt = pk_elts.eq(0)
+            self.assertIn(ts.name, elt.text(), 'Timeslot name should appear in the element for {}'.format(ts))
+            self.assertIn(str(ts.type), elt.text(), 'Timeslot type should appear in the element for {}'.format(ts))
+            self.assertEqual(_col_index(elt), expected_columns[ts.time.date()][ts.time.time()],
+                             'Timeslot {} is in the wrong column'.format(ts))
+            delete_btn = elt.find('.delete-button[data-delete-scope="timeslot"]')
+            self.assertEqual(len(delete_btn), 1,
+                             'Timeslot {} should have one delete button'.format(ts))
+            edit_btn = elt.find('a[href="{}"]'.format(
+                urlreverse('ietf.meeting.views.edit_timeslot',
+                           kwargs=dict(num=meeting.number, slot_id=ts.pk))
+            ))
+            self.assertEqual(len(edit_btn), 1,
+                             'Timeslot {} should have one edit button'.format(ts))
+            # find the room heading for the row
+            tr = elt.closest('tr')
+            self.assertIn(ts.location.name, tr.children('th').eq(0).text(),
+                          'Timeslot {} is not shown in the correct row'.format(ts))
+
+    def test_bulk_delete_buttons_exist(self):
+        """Delete buttons for days and columns should be shown"""
+        meeting = self.create_meeting()
+        for day in range(meeting.days):
+            TimeSlotFactory(
+                meeting=meeting,
+                location=meeting.room_set.first(),
+                time=meeting.get_meeting_date(day) + datetime.timedelta(hours=11),
+            )
+            TimeSlotFactory(
+                meeting=meeting,
+                location=meeting.room_set.first(),
+                time=meeting.get_meeting_date(day) + datetime.timedelta(hours=14),
+            )
+
+        self.login()
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+
+        q = PyQuery(r.content)
+        table = q('#timeslot-table')
+        days = table.find('.day-label')
+        self.assertEqual(len(days), meeting.days, 'Wrong number of day labels')
+        for day_label in days.items():
+            self.assertEqual(len(day_label.find('.delete-button[data-delete-scope="day"]')), 1,
+                             'No delete button for day {}'.format(day_label.text()))
+
+        slots = table.find('.time-label')
+        self.assertEqual(len(slots), 2 * meeting.days, 'Wrong number of slot labels')
+        for slot_label in slots.items():
+            self.assertEqual(len(slot_label.find('.delete-button[data-delete-scope="column"]')), 1,
+                             'No delete button for slot {}'.format(slot_label.text()))
+
+    def test_timeslot_collision_flag(self):
+        """Overlapping timeslots in a room should be flagged
+
+        Only checks exact overlap because that is all we currently handle. The display puts
+        overlapping but not exactly matching timeslots in separate columns which must be
+        manually checked.
+        """
+        meeting = self.create_bare_meeting()
+
+        t1 = TimeSlotFactory(meeting=meeting)
+        TimeSlotFactory(meeting=meeting, time=t1.time, duration=t1.duration, location=t1.location)
+        TimeSlotFactory(meeting=meeting, time=t1.time, duration=t1.duration)  # other location
+        TimeSlotFactory(meeting=meeting, time=t1.time.replace(hour=t1.time.hour + 1), location=t1.location)  # other time
+
+        self.login()
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+
+        q = PyQuery(r.content)
+        slots = q('#timeslot-table .tscell')
+        self.assertEqual(len(slots), 4)  # one per location per distinct time
+        collision = slots.filter('.timeslot-collision')
+        no_collision = slots.filter(':not(.timeslot-collision)')
+        self.assertEqual(len(collision), 1, 'Wrong number of timeslot collisions flagged')
+        self.assertEqual(len(no_collision), 3, 'Wrong number of non-colliding timeslots')
+        # check that the cell containing t1 is the one flagged as a conflict
+        self.assertEqual(len(collision.find('#timeslot{}'.format(t1.pk))), 1,
+                         'Wrong timeslot cell flagged as having a collision')
+
+    def test_timeslot_in_use_flag(self):
+        """Timeslots that are in use should be flagged"""
+        meeting = self.create_meeting()
+
+        # assign sessions to some timeslots
+        empty, has_official, has_other = TimeSlotFactory.create_batch(3, meeting=meeting, location=meeting.room_set.first())
+        SchedTimeSessAssignment.objects.create(
+            timeslot=has_official,
+            session=SessionFactory(meeting=meeting, add_to_schedule=False),
+            schedule=meeting.schedule,  # official schedule
+        )
+
+        SchedTimeSessAssignment.objects.create(
+            timeslot=has_other,
+            session=SessionFactory(meeting=meeting, add_to_schedule=False),
+            schedule=ScheduleFactory(meeting=meeting),  # not the official schedule
+        )
+
+        # get the page
+        self.login()
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+
+        # now check that all timeslots appear, flagged appropriately
+        q = PyQuery(r.content)
+        empty_elt = q('#timeslot{}'.format(empty.pk))
+        has_official_elt = q('#timeslot{}'.format(has_official.pk))
+        has_other_elt = q('#timeslot{}'.format(has_other.pk))
+
+        self.assertEqual(empty_elt.attr('data-unofficial-use'), 'false', 'Unused timeslot should not be in use')
+        self.assertEqual(empty_elt.attr('data-official-use'), 'false', 'Unused timeslot should not be in use')
+
+        self.assertEqual(has_other_elt.attr('data-unofficial-use'), 'true',
+                         'Unofficially used timeslot should be flagged')
+        self.assertEqual(has_other_elt.attr('data-official-use'), 'false',
+                         'Unofficially used timeslot is not in official use')
+
+        self.assertEqual(has_official_elt.attr('data-unofficial-use'), 'false',
+                         'Officially used timeslot not in unofficial use')
+        self.assertEqual(has_official_elt.attr('data-official-use'), 'true',
+                         'Officially used timeslot should be flagged')
+
+    def test_edit_timeslot(self):
+        """Edit page should work as expected"""
+        meeting = self.create_meeting()
+
+        name_before = 'Name Classic (tm)'
+        type_before = 'regular'
+        time_before = datetime.datetime.combine(
+            meeting.date,
+            datetime.time(hour=10),
+        )
+        duration_before = datetime.timedelta(minutes=60)
+        show_location_before = True
+        location_before = meeting.room_set.first()
+        ts = TimeSlotFactory(
+            meeting=meeting,
+            name=name_before,
+            type_id=type_before,
+            time=time_before,
+            duration=duration_before,
+            show_location=show_location_before,
+            location=location_before,
+        )
+
+        self.login()
+        name_after = 'New Name (tm)'
+        type_after = 'plenary'
+        time_after = time_before.replace(day=time_before.day + 1, hour=time_before.hour + 2)
+        duration_after = duration_before * 2
+        show_location_after = not show_location_before
+        location_after = meeting.room_set.last()
+        r = self.client.post(
+            urlreverse('ietf.meeting.views.edit_timeslot',
+                       kwargs=dict(num=meeting.number, slot_id=ts.pk)),
+            data=dict(
+                name=name_after,
+                type=type_after,
+                time_0=time_after.strftime('%Y-%m-%d'),  # date for SplitDateTimeField
+                time_1=time_after.strftime('%H:%M'),  # time for SplitDateTimeField
+                duration=str(duration_after),
+                show_location=show_location_after,
+                location=location_after.pk,
+            )
+        )
+        self.assertEqual(r.status_code, 302)  # expect redirect to timeslot edit url
+        self.assertEqual(r['Location'], self.edit_timeslots_url(meeting),
+                         'Expected to be redirected to meeting timeslots edit page')
+
+        # check that we changed things
+        self.assertNotEqual(name_before, name_after)
+        self.assertNotEqual(type_before, type_after)
+        self.assertNotEqual(time_before, time_after)
+        self.assertNotEqual(duration_before, duration_after)
+        self.assertNotEqual(location_before, location_after)
+
+        # and that we have the new values
+        ts = TimeSlot.objects.get(pk=ts.pk)
+        self.assertEqual(ts.name, name_after)
+        self.assertEqual(ts.type_id, type_after)
+        self.assertEqual(ts.time, time_after)
+        self.assertEqual(ts.duration, duration_after)
+        self.assertEqual(ts.show_location, show_location_after)
+        self.assertEqual(ts.location, location_after)
+
+    def test_create_single_timeslot(self):
+        """Creating a single timeslot should work"""
+        meeting = self.create_meeting()
+        timeslots_before = set(ts.pk for ts in meeting.timeslot_set.all())
+
+        post_data = dict(
+            name='some name',
+            type='regular',
+            days=str(meeting.date.toordinal()),
+            time='14:37',
+            duration='1:13',  # does not include seconds
+            show_location=True,
+            locations=str(meeting.room_set.first().pk),
+        )
+        self.login()
+        r = self.client.post(
+            self.create_timeslots_url(meeting),
+            data=post_data,
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r['Location'], self.edit_timeslots_url(meeting),
+                         'Expected to be redirected to meeting timeslots edit page')
+
+        self.assertEqual(meeting.timeslot_set.count(), len(timeslots_before) + 1)
+        ts = meeting.timeslot_set.exclude(pk__in=timeslots_before).first()  # only 1
+        self.assertEqual(ts.name, post_data['name'])
+        self.assertEqual(ts.type_id, post_data['type'])
+        self.assertEqual(str(ts.time.date().toordinal()), post_data['days'])
+        self.assertEqual(ts.time.strftime('%H:%M'), post_data['time'])
+        self.assertEqual(str(ts.duration), '{}:00'.format(post_data['duration']))  # add seconds
+        self.assertEqual(ts.show_location, post_data['show_location'])
+        self.assertEqual(str(ts.location.pk), post_data['locations'])
+
+    def test_create_bulk_timeslots(self):
+        """Creating multiple timeslots should work"""
+        meeting = self.create_meeting()
+        timeslots_before = set(ts.pk for ts in meeting.timeslot_set.all())
+        days = [meeting.get_meeting_date(n).date() for n in range(meeting.days)]
+        locations = meeting.room_set.all()
+        post_data = dict(
+            name='some name',
+            type='regular',
+            days=[str(d.toordinal()) for d in days],
+            time='14:37',
+            duration='1:13',  # does not include seconds
+            show_location=True,
+            locations=[str(loc.pk) for loc in locations],
+        )
+        self.login()
+        r = self.client.post(
+            self.create_timeslots_url(meeting),
+            data=post_data,
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r['Location'], self.edit_timeslots_url(meeting),
+                         'Expected to be redirected to meeting timeslots edit page')
+
+        new_slot_count = len(days) * len(locations)
+        self.assertEqual(meeting.timeslot_set.count(), len(timeslots_before) + new_slot_count)
+        day_locs = set((day, loc) for day in days for loc in locations)  # cartesian product
+        for ts in meeting.timeslot_set.exclude(pk__in=timeslots_before):
+            self.assertEqual(ts.name, post_data['name'])
+            self.assertEqual(ts.type_id, post_data['type'])
+            self.assertEqual(ts.time.strftime('%H:%M'), post_data['time'])
+            self.assertEqual(str(ts.duration), '{}:00'.format(post_data['duration']))  # add seconds
+            self.assertEqual(ts.show_location, post_data['show_location'])
+            self.assertIn(ts.time.date(), days)
+            self.assertIn(ts.location, locations)
+            self.assertIn((ts.time.date(), ts.location), day_locs,
+                          'Duplicated day / location found')
+            day_locs.discard((ts.time.date(), ts.location))
+        self.assertEqual(day_locs, set(), 'Not all day/location combinations created')
+
+    def test_ajax_delete_timeslot(self):
+        """AJAX call to delete timeslot should work"""
+        meeting = self.create_bare_meeting()
+        ts_to_del, ts_to_keep = TimeSlotFactory.create_batch(2, meeting=meeting)
+
+        self.login()
+        r = self.client.post(
+            self.edit_timeslots_url(meeting),
+            data=dict(
+                action='delete',
+                slot_id=str(ts_to_del.pk),
+            )
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'Deleted TimeSlot {}'.format(ts_to_del.pk))
+        self.assertNotContains(r, 'Deleted TimeSlot {}'.format(ts_to_keep.pk))
+        self.assertEqual(meeting.timeslot_set.filter(pk=ts_to_del.pk).count(), 0,
+                         'Timeslot not deleted')
+        self.assertEqual(meeting.timeslot_set.filter(pk=ts_to_keep.pk).count(), 1,
+                         'Extra timeslot deleted')
+
+    def test_ajax_delete_timeslots(self):
+        """AJAX call to delete several timeslots should work"""
+        meeting = self.create_bare_meeting()
+        ts_to_del = TimeSlotFactory.create_batch(5, meeting=meeting)
+        ts_to_keep = TimeSlotFactory(meeting=meeting)
+
+        self.login()
+        r = self.client.post(
+            self.edit_timeslots_url(meeting),
+            data=dict(
+                action='delete',
+                slot_id=','.join(str(ts.pk) for ts in ts_to_del),
+            )
+        )
+        self.assertEqual(r.status_code, 200)
+        for ts in ts_to_del:
+            self.assertContains(r, 'Deleted TimeSlot {}'.format(ts.pk))
+        self.assertNotContains(r, 'Deleted TimeSlot {}'.format(ts_to_keep.pk))
+        self.assertEqual(
+            meeting.timeslot_set.filter(pk__in=(ts.pk for ts in ts_to_del)).count(),
+            0,
+            'Timeslots not deleted',
+        )
+        self.assertEqual(meeting.timeslot_set.filter(pk=ts_to_keep.pk).count(), 1,
+                         'Extra timeslot deleted')
 
 class ReorderSlidesTests(TestCase):
 

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -1686,7 +1686,12 @@ class EditTimeslotsTests(TestCase):
         return urlreverse('ietf.meeting.views.edit_timeslots', kwargs={'num': meeting.number})
 
     @staticmethod
-    def create_ietf_meeting(number=120):
+    def create_timeslots_url(meeting):
+        return urlreverse('ietf.meeting.views.create_timeslot', kwargs={'num': meeting.number})
+
+    @staticmethod
+    def create_bare_meeting(number=120):
+        """Create a basic IETF meeting"""
         return MeetingFactory(
             type_id='ietf',
             number=number,
@@ -1717,6 +1722,13 @@ class EditTimeslotsTests(TestCase):
         meeting.schedule = schedule
         meeting.save()
 
+    def create_meeting(self, number=120):
+        """Create a meeting ready for adding timeslots in the usual workflow"""
+        meeting = self.create_bare_meeting(number=number)
+        RoomFactory.create_batch(8, meeting=meeting)
+        self.create_initial_schedule(meeting)
+        return meeting
+
     def test_view_permissions(self):
         """Only the secretary should be able to edit timeslots"""
         # test prep and helper method
@@ -1725,7 +1737,7 @@ class EditTimeslotsTests(TestCase):
             RoleFactory(name_id='chair').person.user.username,
             RoleFactory(name_id='ad', group__type_id='area').person.user.username,
         ]
-        meeting = self.create_ietf_meeting()
+        meeting = self.create_bare_meeting()
         url = self.edit_timeslots_url(meeting)
 
         def _assert_permissions(comment):
@@ -1759,7 +1771,7 @@ class EditTimeslotsTests(TestCase):
         """The edit timeslots view be linked from the agenda list view"""
         ad = RoleFactory(name_id='ad', group__type_id='area').person
 
-        meeting = self.create_ietf_meeting()
+        meeting = self.create_bare_meeting()
         self.create_initial_schedule(meeting)
 
         url = urlreverse('ietf.meeting.views.list_schedules', kwargs={'num': meeting.number})
@@ -1782,11 +1794,93 @@ class EditTimeslotsTests(TestCase):
         q = PyQuery(r.content)
         self.assertGreaterEqual(
             len(q('a[href="{}"]'.format(self.edit_timeslots_url(meeting)))),
-            0,
+            1,
             'Must be at least one link from the agenda list page to the edit timeslots page'
         )
 
+    def assert_helpful_url(self, response, helpful_url, message):
+        q = PyQuery(response.content)
+        self.assertGreaterEqual(
+            len(q('.timeslot-edit a[href="{}"]'.format(helpful_url))),
+            1,
+            message,
+        )
 
+    def test_with_no_rooms(self):
+        """Editor should be helpful when there are no rooms yet"""
+        meeting = self.create_bare_meeting()
+        self.client.login(username='secretary', password='secretary+password')
+
+        # with no schedule, should get a link to the meeting page in the secr app until we can
+        # handle this situation in the meeting app
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+        self.assert_helpful_url(
+            r,
+            urlreverse('ietf.secr.meetings.views.view', kwargs={'meeting_id': meeting.number}),
+            'Must be a link to a helpful URL when there are no rooms and no schedule'
+        )
+
+        # with a schedule, should get a link to the create rooms page in the secr app
+        self.create_initial_schedule(meeting)
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+        self.assert_helpful_url(
+            r,
+            urlreverse('ietf.secr.meetings.views.rooms',
+                       kwargs={'meeting_id': meeting.number, 'schedule_name': meeting.schedule.name}),
+            'Must be a link to a helpful URL when there are no rooms'
+        )
+
+    def test_with_no_timeslots(self):
+        """Editor should be helpful when there are rooms but no timeslots yet"""
+        meeting = self.create_bare_meeting()
+        RoomFactory(meeting=meeting)
+        self.client.login(username='secretary', password='secretary+password')
+        helpful_url = self.create_timeslots_url(meeting)
+
+        # with no schedule, should get a link to the meeting page in the secr app until we can
+        # handle this situation in the meeting app
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+        self.assert_helpful_url(r, helpful_url,
+                                 'Must be a link to a helpful URL when there are no timeslots and no schedule')
+
+        # with a schedule, should get a link to the create rooms page in the secr app
+        self.create_initial_schedule(meeting)
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+        self.assert_helpful_url(r, helpful_url,
+                                 'Must be a link to a helpful URL when there are no timeslots')
+
+    def assert_required_links_present(self, response, meeting):
+        """Assert that required links on the editor page are present"""
+        q = PyQuery(response.content)
+        self.assertGreaterEqual(
+            len(q('a[href="{}"]'.format(self.create_timeslots_url(meeting)))),
+            1,
+            'Timeslot edit page should have a link to create timeslots'
+        )
+        self.assertGreaterEqual(
+            len(q('a[href="{}"]'.format(urlreverse('ietf.secr.meetings.views.rooms',
+                                                   kwargs={'meeting_id': meeting.number,
+                                                           'schedule_name': meeting.schedule.name}))
+                  )),
+            1,
+            'Timeslot edit page should have a link to edit rooms'
+        )
+
+    def test_required_links_present(self):
+        """Editor should have links to create timeslots and edit rooms"""
+        meeting = self.create_meeting()
+        self.create_initial_schedule(meeting)
+        RoomFactory.create_batch(8, meeting=meeting)
+
+        self.client.login(username='secretary', password='secretary+password')
+        r = self.client.get(self.edit_timeslots_url(meeting))
+        self.assertEqual(r.status_code, 200)
+        self.assert_required_links_present(r, meeting)
 
 
 class ReorderSlidesTests(TestCase):

--- a/ietf/meeting/urls.py
+++ b/ietf/meeting/urls.py
@@ -53,6 +53,8 @@ type_ietf_only_patterns = [
     url(r'^agendas/diff/$', views.diff_schedules),
     url(r'^agenda/new/$', views.new_meeting_schedule),
     url(r'^timeslots/edit$',                     views.edit_timeslots),
+    url(r'^timeslot/new$',                       views.create_timeslot),
+    url(r'^timeslot/(?P<slot_id>\d+)/edit$',     views.edit_timeslot),
     url(r'^timeslot/(?P<slot_id>\d+)/edittype$', views.edit_timeslot_type),
     url(r'^rooms$',                              ajax.timeslot_roomsurl),
     url(r'^room/(?P<roomid>\d+).json$',          ajax.timeslot_roomurl),

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -529,6 +529,14 @@ def swap_meeting_schedule_timeslot_assignments(schedule, source_timeslots, targe
                 for a in lts_assignments:
                     a.delete()
 
+def bulk_create_timeslots(meeting, times, locations, other_props):
+    """Creates identical timeslots for Cartesian product of times and locations"""
+    for time in times:
+        for loc in locations:
+            properties = dict(time=time, location=loc)
+            properties.update(other_props)
+            meeting.timeslot_set.create(**properties)
+
 def preprocess_meeting_important_dates(meetings):
     for m in meetings:
         m.cached_updated = m.updated()

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -381,16 +381,23 @@ def edit_timeslots(request, num=None):
         else:
             return HttpResponseBadRequest('unknown action')
 
-    time_slices,date_slices,slots = meeting.build_timeslices()
+    # Labels here differ from those in the build_timeslices() method. The labels here are
+    # relative to the table: time_slices are the row headings (ie, days), date_slices are
+    # the column headings (i.e., time intervals), and slots are the per-day list of time slots
+    # (with only one time slot per unique time/duration)
+    time_slices, date_slices, slots = meeting.build_timeslices()
 
     ts_list = deque()
     rooms = meeting.room_set.order_by("capacity","name","id")
     for room in rooms:
         for day in time_slices:
             for slice in date_slices[day]:
-                ts_list.append(room.timeslot_set.filter(time=slice[0],duration=datetime.timedelta(seconds=slice[2])).first())
+                ts_list.append(room.timeslot_set.filter(time=slice[0],duration=datetime.timedelta(seconds=slice[2])))
 
-
+    # Grab these in one query each to identify sessions that are in use and should be handled with care
+    ts_with_official_assignments = meeting.timeslot_set.filter(sessionassignments__schedule=meeting.schedule)
+    ts_with_any_assignments = meeting.timeslot_set.filter(sessionassignments__isnull=False)
+    
     return render(request, "meeting/timeslot_edit.html",
                                          {"rooms":rooms,
                                           "time_slices":time_slices,
@@ -398,6 +405,8 @@ def edit_timeslots(request, num=None):
                                           "date_slices":date_slices,
                                           "meeting":meeting,
                                           "ts_list":ts_list,
+                                          "ts_with_official_assignments": ts_with_official_assignments,
+                                          "ts_with_any_assignments": ts_with_any_assignments,
                                       })
 
 class NewScheduleForm(forms.ModelForm):
@@ -4166,7 +4175,7 @@ def create_timeslot(request, num):
             bulk_create_timeslots(
                 meeting,
                 [datetime.datetime.combine(day, form.cleaned_data['time'])
-                 for day in form.cleaned_data['days']],
+                 for day in form.cleaned_data.get('days', [])],
                 form.cleaned_data['locations'],
                 dict(
                     name=form.cleaned_data['name'],

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1483,6 +1483,7 @@ def list_schedules(request, num):
     return render(request, "meeting/schedule_list.html", {
         'meeting': meeting,
         'schedule_groups': schedule_groups,
+        'can_edit_timeslots': is_secretariat,
     })
 
 class DiffSchedulesForm(forms.Form):

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -383,8 +383,8 @@ def edit_timeslots(request, num=None):
                 return HttpResponseBadRequest('invalid slot_id specification')
             missing_ids = set(slot_ids).difference(str(ts.pk) for ts in timeslots)
             if len(missing_ids) != 0:
-                return HttpResponseNotFound('TimeSlot ids not found in meeting {}: '.format(
-                    num,
+                return HttpResponseNotFound('TimeSlot ids not found in meeting {}: {}'.format(
+                    meeting.number,
                     ', '.join(sorted(missing_ids))
                 ))
             timeslots.delete()

--- a/ietf/secr/meetings/forms.py
+++ b/ietf/secr/meetings/forms.py
@@ -130,6 +130,13 @@ class MeetingRoomForm(forms.ModelForm):
         model = Room
         exclude = ['resources']
 
+class MeetingRoomOptionsForm(forms.Form):
+    copy_timeslots = forms.BooleanField(
+        required=False,
+        initial=False,
+        label='Duplicate timeslots from previous meeting for new rooms?',
+    )
+
 class TimeSlotForm(forms.Form):
     day = forms.ChoiceField()
     time = forms.TimeField()

--- a/ietf/secr/meetings/views.py
+++ b/ietf/secr/meetings/views.py
@@ -26,7 +26,7 @@ from ietf.group.models import Group, GroupEvent
 from ietf.secr.meetings.blue_sheets import create_blue_sheets
 from ietf.secr.meetings.forms import ( BaseMeetingRoomFormSet, MeetingModelForm, MeetingSelectForm,
     MeetingRoomForm, MiscSessionForm, TimeSlotForm, RegularSessionEditForm,
-    UploadBlueSheetForm )
+    UploadBlueSheetForm, MeetingRoomOptionsForm )
 from ietf.secr.proceedings.utils import handle_upload_file
 from ietf.secr.sreq.views import get_initial_session
 from ietf.secr.utils.meeting import get_session, get_timeslot
@@ -637,29 +637,34 @@ def rooms(request, meeting_id, schedule_name):
             return redirect('ietf.secr.meetings.views.main', meeting_id=meeting_id,schedule_name=schedule_name)
 
         formset = RoomFormset(request.POST, instance=meeting, prefix='room')
-        if formset.is_valid():
+        options_form = MeetingRoomOptionsForm(request.POST)
+        if formset.is_valid() and options_form.is_valid():
             formset.save()
 
-            # if we are creating rooms for the first time create full set of timeslots
-            if first_time:
-                build_timeslots(meeting)
+            # only create timeslots on request
+            if options_form.cleaned_data['copy_timeslots']:
+                # if we are creating rooms for the first time create full set of timeslots
+                if first_time:
+                    build_timeslots(meeting)
 
-            # otherwise if we're modifying rooms
-            else:
-                # add timeslots for new rooms, deleting rooms automatically deletes timeslots
-                for form in formset.forms[formset.initial_form_count():]:
-                    if form.instance.pk:
-                        build_timeslots(meeting,room=form.instance)
+                # otherwise if we're modifying rooms
+                else:
+                    # add timeslots for new rooms, deleting rooms automatically deletes timeslots
+                    for form in formset.forms[formset.initial_form_count():]:
+                        if form.instance.pk:
+                            build_timeslots(meeting,room=form.instance)
 
             messages.success(request, 'Meeting Rooms changed successfully')
             return redirect('ietf.secr.meetings.views.rooms', meeting_id=meeting_id, schedule_name=schedule_name)
     else:
         formset = RoomFormset(instance=meeting, prefix='room')
+        options_form = MeetingRoomOptionsForm()
 
     return render(request, 'meetings/rooms.html', {
         'meeting': meeting,
         'schedule': schedule,
         'formset': formset,
+        'options_form': options_form,
         'selected': 'rooms'}
     )
 

--- a/ietf/secr/templates/meetings/misc_sessions.html
+++ b/ietf/secr/templates/meetings/misc_sessions.html
@@ -49,7 +49,7 @@
       </tbody>
     </table>
     {% else %}
-      <h3>No timeslots exist for this meeting.  First add the rooms and then the app will create timeslots based on the schedule from the last meeting.</h3>
+      <h3>No timeslots exist for this meeting. Add rooms with the "duplicate timeslots" option enabled to copy timeslots from the last meeting.</h3>
     {% endif %}
     <br /><hr />
     

--- a/ietf/secr/templates/meetings/rooms.html
+++ b/ietf/secr/templates/meetings/rooms.html
@@ -11,7 +11,8 @@
             <form id="meetings-meta-rooms" action="" method="post">{% csrf_token %}
               {{ formset.management_form }}
               {{ formset.non_form_errors }}
-              
+              {% if options_form %}{{ options_form.errors }}{% endif %}
+
               <table id="id_rooms_table" class="full-width">
                 <thead>
                  <tr>
@@ -43,9 +44,10 @@
           </div> <!-- iniline-related -->
         </div> <!-- inline-group -->
         
-        {% include "includes/buttons_save.html" %}
+  {% if options_form %}{{ options_form }}{% endif %}
+  {% include "includes/buttons_save.html" %}
       
-      </form>
+  </form>
 </div> <!-- module -->
 
 {% endblock %}

--- a/ietf/secr/templates/meetings/times.html
+++ b/ietf/secr/templates/meetings/times.html
@@ -29,7 +29,7 @@
       </tbody>
     </table>
     {% else %}
-      <h3>No timeslots exist for this meeting.  First add the rooms and then the app will create timeslots based on the schedule from the last meeting.</h3>
+      <h3>No timeslots exist for this meeting. Add rooms with the "duplicate timeslots" option enabled to copy timeslots from the last meeting.</h3>
     {% endif %}
     <br /><hr />
     

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1545,6 +1545,31 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   width: 10em;
 }
 
+.timeslot-edit .tstable .ts-type {
+    font-size: smaller;
+}
+
+.timeslot-edit .tstable .timeslot.in-official-use {
+    background-color: #d9edf7;
+}
+
+.timeslot-edit .tstable .timeslot.in-unofficial-use {
+    background-color: #f8f8e0;
+}
+
+.timeslot-edit .tstable td.timeslot-collision {
+    background-color: #ffa0a0;
+}
+
+.timeslot-edit .tstable .tstype_unavail {
+    background-color:#666;
+}
+
+.timeslot-edit .official-use-warning {
+    color: #ff0000;
+}
+
+
 .rightmarker, .leftmarker {
     width: 3px;
     padding-right: 0px !important;

--- a/ietf/static/ietf/css/ietf.css
+++ b/ietf/static/ietf/css/ietf.css
@@ -1545,8 +1545,21 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
   width: 10em;
 }
 
-.timeslot-edit .tstable .ts-type {
+.timeslot-edit .tstable div.timeslot {
+    border: #000000 solid 1px;
+    border-radius: 0.5em;
+    padding: 0.5em;
+}
+
+.timeslot-edit .tstable .timeslot .ts-name {
+    overflow: hidden;
+}
+.timeslot-edit .tstable .timeslot .ts-type {
     font-size: smaller;
+}
+
+.timeslot-edit .tstable .timeslot .timeslot-buttons {
+    float: right;
 }
 
 .timeslot-edit .tstable .timeslot.in-official-use {
@@ -1568,7 +1581,6 @@ a.fc-event, .fc-event, .fc-content, .fc-title, .fc-event-container {
 .timeslot-edit .official-use-warning {
     color: #ff0000;
 }
-
 
 .rightmarker, .leftmarker {
     width: 3px;

--- a/ietf/templates/meeting/create_timeslot.html
+++ b/ietf/templates/meeting/create_timeslot.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{# Copyright The IETF Trust 2021, All Rights Reserved #}
+{% load origin %}
+{% load bootstrap3 %}
+
+{% block title %}Create timeslot for {{meeting}}{% endblock %}
+
+{% block content %}
+  {% origin %}
+  <h1>Create timeslot for {{meeting}}</h1>
+  <form method="post">
+    {% csrf_token %}
+    {% bootstrap_form form %}
+    {% buttons %}
+      <button type="submit" class="btn btn-primary">Save</button>
+      <a class="btn btn-default" href="{% url 'ietf.meeting.views.edit_timeslots' num=meeting.number %}">Cancel</a>
+    {% endbuttons %}
+  </form>
+{% endblock %}

--- a/ietf/templates/meeting/create_timeslot.html
+++ b/ietf/templates/meeting/create_timeslot.html
@@ -3,6 +3,10 @@
 {% load origin %}
 {% load bootstrap3 %}
 
+{% block pagehead %}
+  {{ form.media.css }}
+{% endblock %}
+
 {% block title %}Create timeslot for {{meeting}}{% endblock %}
 
 {% block content %}
@@ -16,4 +20,8 @@
       <a class="btn btn-default" href="{% url 'ietf.meeting.views.edit_timeslots' num=meeting.number %}">Cancel</a>
     {% endbuttons %}
   </form>
+{% endblock %}
+
+{% block js %}
+  {{ form.media.js }}
 {% endblock %}

--- a/ietf/templates/meeting/edit_timeslot.html
+++ b/ietf/templates/meeting/edit_timeslot.html
@@ -3,11 +3,15 @@
 {% load origin %}
 {% load bootstrap3 %}
 
-{% block title %}Edit timeslot {{timeslot}}{% endblock %}
+{% block pagehead %}
+  {{ form.media.css }}
+{% endblock %}
+
+{% block title %}Edit timeslot "{{ timeslot.name }}" for {{ timeslot.meeting }}{% endblock %}
 
 {% block content %}
   {% origin %}
-  <h1>Edit timeslot {{timeslot}}</h1>
+  <h1>Edit timeslot "{{ timeslot.name }}" for {{ timeslot.meeting }}</h1>
   {% if sessions %}
     <div class="alert alert-warning">
       This timeslot currently has the following sessions assigned to it:
@@ -24,4 +28,8 @@
       <a class="btn btn-default" href="{% url 'ietf.meeting.views.edit_timeslots' num=timeslot.meeting.number %}">Cancel</a>
     {% endbuttons %}
   </form>
+{% endblock %}
+
+{% block js %}
+  {{ form.media.js }}
 {% endblock %}

--- a/ietf/templates/meeting/edit_timeslot.html
+++ b/ietf/templates/meeting/edit_timeslot.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{# Copyright The IETF Trust 2021, All Rights Reserved #}
+{% load origin %}
+{% load bootstrap3 %}
+
+{% block title %}Edit timeslot {{timeslot}}{% endblock %}
+
+{% block content %}
+  {% origin %}
+  <h1>Edit timeslot {{timeslot}}</h1>
+  {% if sessions %}
+    <div class="alert alert-warning">
+      This timeslot currently has the following sessions assigned to it:
+      {% for s in sessions %}
+        <div>{{s}}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    {% bootstrap_form form %}
+    {% buttons %}
+      <button type="submit" class="btn btn-primary">Save</button>
+      <a class="btn btn-default" href="{% url 'ietf.meeting.views.edit_timeslots' num=timeslot.meeting.number %}">Cancel</a>
+    {% endbuttons %}
+  </form>
+{% endblock %}

--- a/ietf/templates/meeting/schedule_list.html
+++ b/ietf/templates/meeting/schedule_list.html
@@ -10,6 +10,9 @@
   <h1>{% block title %}Possible Meeting Agendas for IETF {{ meeting.number }}{% endblock %}</h1>
 
   <div>
+    {% if can_edit_timeslots %}
+      <p><a href="{% url "ietf.meeting.views.edit_timeslots" num=meeting.number %}">Edit timeslots and room availability</a></p>
+    {% endif %}
     {% for schedules, own, label in schedule_groups %}
       <div class="panel panel-default">
         <div class="panel-heading">

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -3,7 +3,7 @@
 {% load origin %}
 {% load agenda_custom_tags %}
 
-{% block title %}IETF {{ meeting.number }} Meeting Agenda: Timeslot/Room Availability{% endblock %}
+{% block title %}IETF {{ meeting.number }} Meeting Agenda: Timeslots and Room Availability{% endblock %}
 
 {% block morecss %}
   .tstable { width: 100%;}
@@ -18,6 +18,8 @@
   <p class="pull-right">
     <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">New timeslot</a>
   </p>
+
+  <p> IETF {{ meeting.number }} Meeting Agenda: Timeslots and Room Availability</p>
   <div class="timeslot-edit">
   <table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
     <thead>
@@ -83,7 +85,11 @@
         </div>
 
         <div class="modal-body">
-          <p>The following <span class="ts-singular">timeslot</span><span class="ts-plural"><span class="ts-count"></span> timeslots</span> will be deleted:</p>
+          <p>
+            <span class="ts-singular">The following timeslot</span>
+            <span class="ts-plural"><span class="ts-count"></span> timeslots</span>
+            will be deleted:
+          </p>
           <dl class="dl-horizontal">
             <dt>Name</dt><dd><span class="ts-name"></span></dd>
             <dt>Date</dt><dd><span class="ts-date"></span></dd>

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -26,6 +26,11 @@
       {% for day in time_slices %}
         <th colspan="{{date_slices|colWidth:day}}">
           {{day|date:'D'}}&nbsp;({{day}})
+          <span class="fa fa-trash delete-button"
+                title="Delete all on this day"
+                data-delete-scope="day"
+                data-date-id="{{ day.isoformat }}">
+          </span>
         </th>
       {% endfor %}
     </tr>
@@ -34,7 +39,13 @@
       {% for day in time_slices %}
         {% for slot in slot_slices|lookup:day %}
           <th>
-            {{slot.time|date:'Hi'}}-{{slot.end_time|date:'Hi'}}
+            {{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}
+            <span class="fa fa-trash delete-button"
+                  data-delete-scope="column"
+                  data-date-id="{{ day.isoformat }}"
+                  data-col-id="{{ day.isoformat }}T{{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}"
+                  title="Delete all in this column">
+            </span>
           </th>
         {% endfor %}
       {% endfor %}
@@ -107,10 +118,11 @@
   // create a namespace for local JS
   timeslotEdit = (function() {
     let deleteModal;
+    let timeslotTableBody = document.querySelector('#timeslot-table tbody');
 
     function initializeDeleteModal() {
       deleteModal = jQuery('#delete-modal');
-      deleteModal.deletePk = null; // PK of TimeSlot that modal 'Delete' button should delete
+      deleteModal.eltsToDelete = null; // PK of TimeSlot that modal 'Delete' button should delete
       deleteModal.elts = {
         unofficialUseWarning: deleteModal.find('.unofficial-use-warning'),
         officialUseWarning: deleteModal.find('.official-use-warning'),
@@ -125,14 +137,10 @@
         () => timeslotEdit.handleDeleteButtonClick()
       );
 
-      document.getElementById('timeslot-table').addEventListener('click', function(event) {
-        let clicked = event.target; // find out what was clicked
-        if (clicked.classList.contains('timeslot-delete-button')) {
-          // handle timeslot delete button click
-          let timeslotElt = clicked.closest('.timeslot');
+      deleteModal.openModal = function (eltsToDelete) {
+        eltsToDelete.forEach(timeslotElt => {
           let unofficialUse = Boolean(timeslotElt.dataset.unofficialUse === 'true'); // is a session assigned in any schedule?
           let officialUse = Boolean(timeslotElt.dataset.officialUse === 'true'); // is a session assigned in the official schedule?
-
           deleteModal.elts.unofficialUseWarning.hide();
           deleteModal.elts.officialUseWarning.hide();
           deleteModal.elts.timeslotNameSpans.text(timeslotElt.dataset.timeslotName);
@@ -144,9 +152,76 @@
           } else if (unofficialUse) {
             deleteModal.elts.unofficialUseWarning.show();
           }
+        });
 
-          deleteModal.deletePk  = timeslotElt.dataset.timeslotPk;
-          deleteModal.modal('show');
+        deleteModal.eltsToDelete  = eltsToDelete;
+        deleteModal.modal('show');
+      }
+
+      /**
+       * Handle deleting a single timeslot
+       *
+       * clicked arg is the clicked element, which must be a child of the timeslot element
+       */
+      function deleteSingleTimeSlot(clicked) {
+        deleteModal.openModal([clicked.closest('.timeslot')]);
+      }
+
+      /**
+       * Handle deleting an entire day worth of timeslots
+       *
+       * clicked arg is the clicked element, which must be a child of the day header element
+       */
+      function deleteDay(clicked) {
+        // Find all timeslots for this day
+        let dateId = clicked.dataset.dateId;
+        let timeslots = timeslotTableBody.querySelectorAll(
+          ':scope .timeslot[data-date-id="' + dateId + '"]' // :scope prevents picking up results outside table body
+        );
+        if (timeslots.length > 0) {
+          deleteModal.openModal(timeslots);
+        }
+      }
+
+      /**
+       * Handle deleting an entire column worth of timeslots
+       *
+       * clicked arg is the clicked element, which must be a child of the column header element
+       */
+      function deleteColumn(clicked) {
+        let colId = clicked.dataset.colId;
+        let timeslots = timeslotTableBody.querySelectorAll(
+          ':scope .timeslot[data-col-id="' + colId + '"]' // :scope prevents picking up results outside table body
+        );
+        if (timeslots.length > 0) {
+          deleteModal.openModal(timeslots);
+        }
+      }
+
+      /**
+       * Event handler for clicks on the timeslot table
+       *
+       * Handles clicks on all the delete buttons to avoid large numbers of event handlers.
+       */
+      document.getElementById('timeslot-table').addEventListener('click', function(event) {
+        let clicked = event.target; // find out what was clicked
+        if (clicked.dataset.deleteScope) {
+          switch (clicked.dataset.deleteScope) {
+            case 'timeslot':
+              deleteSingleTimeSlot(clicked)
+              break
+
+            case 'column':
+              deleteColumn(clicked)
+              break
+
+            case 'day':
+              deleteDay(clicked)
+              break
+
+            default:
+              throw new Error('Unexpected deleteScope "' + clicked.dataset.deleteScope + '"')
+          }
         }
       });
     }
@@ -182,7 +257,7 @@
 
     function initializeTsTableObserver() {
       const observer = new MutationObserver(tstableObserveCallback);
-      observer.observe(document.querySelector('#timeslot-table tbody'), { childList: true, subtree: true });
+      observer.observe(timeslotTableBody, { childList: true, subtree: true });
     }
 
     window.addEventListener('load', function (event) {
@@ -197,32 +272,32 @@
     }
 
     function handleDeleteButtonClick() {
-      if (!deleteModal || !deleteModal.deletePk) {
-        return; // do nothing it not yet initialized
+      if (!deleteModal || !deleteModal.eltsToDelete) {
+        return; // do nothing if not yet initialized
       }
 
-      let timeslotElt = document.getElementById('timeslot' + String(deleteModal.deletePk));
-      deleteTimeSlot(deleteModal.deletePk)
+      let timeslotElts = Array.from(deleteModal.eltsToDelete); // make own copy as Array so we have .map()
+      ajaxDeleteTimeSlot(timeslotElts.map(elt => elt.dataset.timeslotPk))
       .error(function(jqXHR, textStatus) {
         displayError('Error deleting timeslot: ' + jqXHR.responseText)
       })
-      .done(function () {timeslotElt.parentNode.removeChild(timeslotElt)})
+      .done(function () {timeslotElts.forEach(tse => tse.parentNode.removeChild(tse))})
       .always(function () {deleteModal.modal('hide')});
     }
 
     /**
      * Make an AJAX request to delete a TimeSlot
      *
-     * @param id ID of TimeSlot to delete
+     * @param pkArray array of PKs of timeslots to delete
      * @returns jqXHR object corresponding to jQuery ajax request
      */
-    function deleteTimeSlot(id) {
+    function ajaxDeleteTimeSlot(pkArray) {
       return jQuery.ajax({
         method: 'post',
         timeout: 5 * 1000,
         data: {
           action: 'delete',
-          slot_id: String(id)
+          slot_id: pkArray.join(',')
         }
       });
     }

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -17,60 +17,94 @@
 
   <p class="pull-right">
     <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">New timeslot</a>
+    &middot;
+    {% if meeting.schedule %}
+      <a href="{% url "ietf.secr.meetings.views.rooms" meeting_id=meeting.number schedule_name=meeting.schedule.name %}">Edit rooms</a>
+    {% else %} {# secr app room view requires a schedule - show something for now (should try to avoid this possibility) #}
+      <span title="Must create meeting schedule to edit rooms">Edit rooms</span>
+    {% endif %}
   </p>
 
   <p> IETF {{ meeting.number }} Meeting Agenda: Timeslots and Room Availability</p>
   <div class="timeslot-edit">
-  <table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
-    <thead>
-    <tr>
-      <th></th>
-      {% for day in time_slices %}
-        <th colspan="{{date_slices|colWidth:day}}">
-          {{day|date:'D'}}&nbsp;({{day}})
-          <span class="fa fa-trash delete-button"
-                title="Delete all on this day"
-                data-delete-scope="day"
-                data-date-id="{{ day.isoformat }}">
-          </span>
-        </th>
-      {% endfor %}
-    </tr>
-    <tr>
-      <th></th>
-      {% for day in time_slices %}
-        {% for slot in slot_slices|lookup:day %}
-          <th>
-            {{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}
-            <span class="fa fa-trash delete-button"
-                  data-delete-scope="column"
-                  data-date-id="{{ day.isoformat }}"
-                  data-col-id="{{ day.isoformat }}T{{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}"
-                  title="Delete all in this column">
-            </span>
-          </th>
-        {% endfor %}
-      {% endfor %}
-    </tr>
-    </thead>
-
-    <tbody>
-    {% for room in rooms %}
+  {% if rooms|length == 0 %}
+    <p>No rooms exist for this meeting yet.</p>
+    {% if meeting.schedule %}
+      <a href="{% url "ietf.secr.meetings.views.rooms" meeting_id=meeting.number schedule_name=meeting.schedule.name %}">Create rooms</a>
+    {% else %}{# provide as helpful a link we can if we don't have an official schedule #}
+      <a href="{% url "ietf.secr.meetings.views.main" meeting_id=meeting.number %}">Create rooms through the secr app</a>
+    {% endif %}
+  {% else %}
+    <table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
+      {% with have_no_timeslots=time_slices|length_is:0 %}
+      <thead>
       <tr>
-        <th>{{room.name}}{% if room.capacity %} <span class='capacity'>({{room.capacity}})</span>{% endif %}</th>
-        {% for day in time_slices %}
-          {% for slice in date_slices|lookup:day %}{% with cell_ts=ts_list.popleft %}
-            <td class="tscell {% if cell_ts|length > 1 %}timeslot-collision {% endif %}{% for ts in cell_ts %}tstype_{{ ts.type.slug }} {% endfor %}">
-            {% for ts in cell_ts %}
-              {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts in_use=ts_with_any_assignments in_official_use=ts_with_official_assignments only %}
-            {% endfor %}
-          {% endwith %}{% endfor %}
-          </td>
-        {% endfor %}
+        {% if have_no_timeslots %}
+          <th></th>
+          <th></th>
+        {% else %}
+          <th></th>
+          {% for day in time_slices %}
+            <th colspan="{{date_slices|colWidth:day}}">
+              {{day|date:'D'}}&nbsp;({{day}})
+              <span class="fa fa-trash delete-button"
+                    title="Delete all on this day"
+                    data-delete-scope="day"
+                    data-date-id="{{ day.isoformat }}">
+              </span>
+            </th>
+          {% endfor %}
+        {% endif %}
       </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+      <tr>
+        {% if have_no_timeslots %}
+          <th></th>
+          <th></th>
+        {% else %}
+          <th></th>
+          {% for day in time_slices %}
+            {% for slot in slot_slices|lookup:day %}
+              <th>
+                {{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}
+                <span class="fa fa-trash delete-button"
+                      data-delete-scope="column"
+                      data-date-id="{{ day.isoformat }}"
+                      data-col-id="{{ day.isoformat }}T{{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}"
+                      title="Delete all in this column">
+                </span>
+              </th>
+            {% endfor %}
+          {% endfor %}
+        {% endif %}
+      </tr>
+      </thead>
+
+      <tbody>
+      {% for room in rooms %}
+        <tr>
+          <th><span class="room-heading">{{room.name}}{% if room.capacity %} <span class='capacity'>({{room.capacity}})</span>{% endif %}</span></th>
+          {% if have_no_timeslots and forloop.first %}
+            <td rowspan="{{ rooms|length }}">
+              <p>No timeslots exist for this meeting yet.</p>
+              <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">Create a timeslot.</a>
+            </td>
+          {% else %}
+            {% for day in time_slices %}
+              {% for slice in date_slices|lookup:day %}{% with cell_ts=ts_list.popleft %}
+                <td class="tscell {% if cell_ts|length > 1 %}timeslot-collision {% endif %}{% for ts in cell_ts %}tstype_{{ ts.type.slug }} {% endfor %}">
+                {% for ts in cell_ts %}
+                  {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts in_use=ts_with_any_assignments in_official_use=ts_with_official_assignments only %}
+                {% endfor %}
+              {% endwith %}{% endfor %}
+              </td>
+            {% endfor %}
+          {% endif %}
+        </tr>
+      {% endfor %}
+      </tbody>
+      {% endwith %}
+    </table>
+  {% endif %}
 
   {# Modal to confirm timeslot deletion #}
   <div id="delete-modal" class="modal" tabindex="-1" role="dialog">

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -32,7 +32,7 @@
     {% if meeting.schedule %}
       <a href="{% url "ietf.secr.meetings.views.rooms" meeting_id=meeting.number schedule_name=meeting.schedule.name %}">Create rooms</a>
     {% else %}{# provide as helpful a link we can if we don't have an official schedule #}
-      <a href="{% url "ietf.secr.meetings.views.main" meeting_id=meeting.number %}">Create rooms through the secr app</a>
+      <a href="{% url "ietf.secr.meetings.views.view" meeting_id=meeting.number %}">Create rooms through the secr app</a>
     {% endif %}
   {% else %}
     <table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -83,7 +83,7 @@
         </div>
 
         <div class="modal-body">
-          <p>The following timeslot will be deleted:</p>
+          <p>The following <span class="ts-singular">timeslot</span><span class="ts-plural"><span class="ts-count"></span> timeslots</span> will be deleted:</p>
           <dl class="dl-horizontal">
             <dt>Name</dt><dd><span class="ts-name"></span></dd>
             <dt>Date</dt><dd><span class="ts-date"></span></dd>
@@ -92,14 +92,22 @@
           </dl>
           <p class="unofficial-use-warning">
             The official schedule will not be affected, but sessions in
-            unofficial schedules currently assigned to this timeslot
+            unofficial schedules currently assigned to
+            <span class="ts-singular">this timeslot</span>
+            <span class="ts-plural">any of these timeslots</span>
             will become unassigned.
           </p>
           <p class="official-use-warning">
             The official schedule will be affected.
-            Sessions currently assigned to this timeslot will become unassigned.
+            Sessions currently assigned to
+            <span class="ts-singular">this timeslot</span>
+            <span class="ts-plural">any of these timeslots</span>
+            will become unassigned.
           </p>
-          <p>Are you sure you want to delete this timeslot?</p>
+          <p>
+            <span class="ts-singular">Are you sure you want to delete this timeslot?</span>
+            <span class="ts-plural">Are you sure you want to delete these <span class="ts-count"></span> timeslots?</span>
+          </p>
         </div>
 
         <div class="modal-footer">
@@ -123,13 +131,17 @@
     function initializeDeleteModal() {
       deleteModal = jQuery('#delete-modal');
       deleteModal.eltsToDelete = null; // PK of TimeSlot that modal 'Delete' button should delete
+      let spans = deleteModal.find('span');
       deleteModal.elts = {
         unofficialUseWarning: deleteModal.find('.unofficial-use-warning'),
         officialUseWarning: deleteModal.find('.official-use-warning'),
-        timeslotNameSpans: deleteModal.find('span.ts-name'),
-        timeslotDateSpans: deleteModal.find('span.ts-date'),
-        timeslotTimeSpans: deleteModal.find('span.ts-time'),
-        timeslotLocSpans: deleteModal.find('span.ts-location')
+        timeslotNameSpans: spans.filter('.ts-name'),
+        timeslotDateSpans: spans.filter('.ts-date'),
+        timeslotTimeSpans: spans.filter('.ts-time'),
+        timeslotLocSpans: spans.filter('.ts-location'),
+        timeslotCountSpans: spans.filter('.ts-count'),
+        pluralSpans: spans.filter('.ts-plural'),
+        singularSpans: spans.filter('.ts-singular')
       };
 
       document.getElementById('confirm-delete-button').addEventListener(
@@ -137,22 +149,66 @@
         () => timeslotEdit.handleDeleteButtonClick()
       );
 
+      function uniqueArray(a) {
+        let s = new Set();
+        a.forEach(item => s.add(item));
+        return Array.from(s);
+      }
       deleteModal.openModal = function (eltsToDelete) {
-        eltsToDelete.forEach(timeslotElt => {
-          let unofficialUse = Boolean(timeslotElt.dataset.unofficialUse === 'true'); // is a session assigned in any schedule?
-          let officialUse = Boolean(timeslotElt.dataset.officialUse === 'true'); // is a session assigned in the official schedule?
-          deleteModal.elts.unofficialUseWarning.hide();
-          deleteModal.elts.officialUseWarning.hide();
-          deleteModal.elts.timeslotNameSpans.text(timeslotElt.dataset.timeslotName);
-          deleteModal.elts.timeslotDateSpans.text(timeslotElt.dataset.timeslotDate);
-          deleteModal.elts.timeslotTimeSpans.text(timeslotElt.dataset.timeslotTime);
-          deleteModal.elts.timeslotLocSpans.text(timeslotElt.dataset.timeslotLocation);
-          if (officialUse) {
-            deleteModal.elts.officialUseWarning.show();
-          } else if (unofficialUse) {
-            deleteModal.elts.unofficialUseWarning.show();
-          }
-        });
+        let eltArray = Array.from(eltsToDelete); // make sure this is an array
+
+        if (eltArray.length > 1) {
+          deleteModal.elts.pluralSpans.show();
+          deleteModal.elts.singularSpans.hide();
+        } else {
+          deleteModal.elts.pluralSpans.hide();
+          deleteModal.elts.singularSpans.show();
+        }
+        deleteModal.elts.timeslotCountSpans.text(String(eltArray.length));
+
+        let names = uniqueArray(eltArray.map(elt => elt.dataset.timeslotName));
+        if (names.length === 1) {
+          names = names[0];
+        } else {
+          names.sort();
+          names = names.join(', ');
+        }
+        deleteModal.elts.timeslotNameSpans.text(names);
+
+        let dates = uniqueArray(eltArray.map(elt => elt.dataset.timeslotDate));
+        if (dates.length === 1) {
+          dates = dates[0];
+        } else {
+          dates = 'Multiple';
+        }
+        deleteModal.elts.timeslotDateSpans.text(dates);
+
+        let times = uniqueArray(eltArray.map(elt => elt.dataset.timeslotTime));
+        if (times.length === 1) {
+          times = times[0];
+        } else {
+          times = 'Multiple';
+        }
+        deleteModal.elts.timeslotTimeSpans.text(times);
+
+        let locs = uniqueArray(eltArray.map(elt => elt.dataset.timeslotLocation));
+        if (locs.length === 1) {
+          locs = locs[0];
+        } else {
+          locs = 'Multiple';
+        }
+        deleteModal.elts.timeslotLocSpans.text(locs);
+
+        // Check whether any of the elts are used in official / unofficial schedules
+        let unofficialUse = eltArray.some(elt => elt.dataset.unofficialUse === 'true');
+        let officialUse = eltArray.some(elt => elt.dataset.officialUse === 'true');
+        deleteModal.elts.unofficialUseWarning.hide();
+        deleteModal.elts.officialUseWarning.hide();
+        if (officialUse) {
+          deleteModal.elts.officialUseWarning.show();
+        } else if (unofficialUse) {
+          deleteModal.elts.unofficialUseWarning.show();
+        }
 
         deleteModal.eltsToDelete  = eltsToDelete;
         deleteModal.modal('show');

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -6,19 +6,21 @@
 {% block title %}IETF {{ meeting.number }} Meeting Agenda: Timeslot/Room Availability{% endblock %}
 
 {% block morecss %}
-.tstable { width: 100%;}
-.tstable th { white-space: nowrap;}
-.tstable td { white-space: nowrap;}
-.capacity { font-size:80%; font-weight: normal;}
+  .tstable { width: 100%;}
+  .tstable th { white-space: nowrap;}
+  .tstable td { white-space: nowrap;}
+  .capacity { font-size:80%; font-weight: normal;}
 
-.tstable .tstype_unavail {background-color:#666;}
+  .tstable .tstype_unavail {background-color:#666;}
 {% endblock %}
 
 {% block content %}
   {% origin %}
 
-
-<table class="tstable table table-striped table-compact table-bordered">
+<p class="pull-right">
+  <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">New timeslot</a>
+</p>
+<table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
   <thead>
   <tr>
   <th></th>
@@ -45,13 +47,52 @@
     <th>{{room.name}}<span class='capacity'>{% if room.capacity %} ({{room.capacity}}){% endif %}</th>
     {% for day in time_slices %}
       {% for slice in date_slices|lookup:day %}
-        {% with ts=ts_list.popleft %}
-          <td{% if ts %} class="tstype_{{ts.type.slug}}"{% endif %}>{% if ts %}<a href="{% url 'ietf.meeting.views.edit_timeslot_type' num=meeting.number slot_id=ts.id %}">{{ts.type.slug}}</a>{% endif %}</td>
-        {% endwith %}
+        {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts_list.popleft only %}
       {% endfor %}
     {% endfor %}
   </tr>
   {% endfor %}
 </table>
 
+{% endblock %}
+
+{% block js %}
+  <script type="text/javascript">
+  window.addEventListener('load', function (event) {
+    document.getElementById('timeslot-table').addEventListener('click', function(event) {
+      let clicked = event.target; // find out what was clicked
+      if (clicked.classList.contains('timeslot-delete-button')) {
+        // handle timeslot delete button click
+        let timeslotElt = clicked.closest('.timeslot');
+        let deleteId = timeslotElt.dataset.timeslotPk;
+        deleteTimeSlot(deleteId)
+        .error(function(jqXHR, textStatus) {
+          displayError('Error deleting timeslot: ' + jqXHR.responseText)
+        })
+        .done(function () {timeslotElt.parentNode.removeChild(timeslotElt)});
+      }
+    })
+  });
+
+  /**
+   * Make an AJAX request to delete a TimeSlot
+   *
+   * @param id ID of TimeSlot to delete
+   * @returns jqXHR object corresponding to jQuery ajax request
+   */
+  function deleteTimeSlot(id) {
+    return jQuery.ajax({
+      method: 'post',
+      timeout: 5 * 1000,
+      data: {
+        action: 'delete',
+        slot_id: String(id)
+      }
+    });
+  }
+
+  function displayError(msg) {
+    window.alert(msg);
+  }
+  </script>
 {% endblock %}

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -93,7 +93,7 @@
 
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button type="button" id="confirm-delete-button" class="btn btn-primary" onclick="timeslotEdit.handleDeleteButtonClick()">Delete</button>
+          <button type="button" id="confirm-delete-button" class="btn btn-primary">Delete</button>
         </div>
       </div>
     </div>
@@ -119,6 +119,11 @@
         timeslotTimeSpans: deleteModal.find('span.ts-time'),
         timeslotLocSpans: deleteModal.find('span.ts-location')
       };
+
+      document.getElementById('confirm-delete-button').addEventListener(
+        'click',
+        () => timeslotEdit.handleDeleteButtonClick()
+      );
 
       document.getElementById('timeslot-table').addEventListener('click', function(event) {
         let clicked = event.target; // find out what was clicked
@@ -166,7 +171,7 @@
           });
 
           // now add timeslot type classes for any remaining timeslots
-          tscell.getElementsByClassName('timeslot').forEach(elt => {
+          Array.from(tscell.getElementsByClassName('timeslot')).forEach(elt => {
             if (elt.dataset.timeslotType) {
               tscell.classList.add('tstype_' + elt.dataset.timeslotType);
             }

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -17,42 +17,42 @@
 {% block content %}
   {% origin %}
 
-<p class="pull-right">
-  <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">New timeslot</a>
-</p>
-<table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
-  <thead>
-  <tr>
-  <th></th>
-  {% for day in time_slices %}
-    <th colspan="{{date_slices|colWidth:day}}"> 
-      {{day|date:'D'}}&nbsp;({{day}})
-    </th>
-  {% endfor %}
-  </tr>
-  <tr>
-    <th></th>
-    {% for day in time_slices %}
-	  {% for slot in slot_slices|lookup:day %}
-	      <th>
-                {{slot.time|date:'Hi'}}-{{slot.end_time|date:'Hi'}}
-              </th>
-	  {% endfor %}
-    {% endfor %}
-  </tr>
-  </thead>
-
-  {% for room in rooms %}
-  <tr>
-    <th>{{room.name}}<span class='capacity'>{% if room.capacity %} ({{room.capacity}}){% endif %}</th>
-    {% for day in time_slices %}
-      {% for slice in date_slices|lookup:day %}
-        {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts_list.popleft only %}
+  <p class="pull-right">
+    <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">New timeslot</a>
+  </p>
+  <table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
+    <thead>
+    <tr>
+      <th></th>
+      {% for day in time_slices %}
+        <th colspan="{{date_slices|colWidth:day}}">
+          {{day|date:'D'}}&nbsp;({{day}})
+        </th>
       {% endfor %}
+    </tr>
+    <tr>
+      <th></th>
+      {% for day in time_slices %}
+        {% for slot in slot_slices|lookup:day %}
+          <th>
+            {{slot.time|date:'Hi'}}-{{slot.end_time|date:'Hi'}}
+          </th>
+        {% endfor %}
+      {% endfor %}
+    </tr>
+    </thead>
+
+    {% for room in rooms %}
+      <tr>
+        <th>{{room.name}}<span class='capacity'>{% if room.capacity %} ({{room.capacity}}){% endif %}</th>
+        {% for day in time_slices %}
+          {% for slice in date_slices|lookup:day %}
+            {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts_list.popleft only %}
+          {% endfor %}
+        {% endfor %}
+      </tr>
     {% endfor %}
-  </tr>
-  {% endfor %}
-</table>
+  </table>
 
 {% endblock %}
 

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -45,7 +45,8 @@
         {% else %}
           <th></th>
           {% for day in time_slices %}
-            <th colspan="{{date_slices|colWidth:day}}">
+            <th class="day-label"
+                colspan="{{date_slices|colWidth:day}}">
               {{day|date:'D'}}&nbsp;({{day}})
               <span class="fa fa-trash delete-button"
                     title="Delete all on this day"
@@ -64,7 +65,7 @@
           <th></th>
           {% for day in time_slices %}
             {% for slot in slot_slices|lookup:day %}
-              <th>
+              <th class="time-label">
                 {{slot.time|date:'H:i'}}-{{slot.end_time|date:'H:i'}}
                 <span class="fa fa-trash delete-button"
                       data-delete-scope="column"

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -59,25 +59,151 @@
     </tbody>
   </table>
 
+  {# Modal to confirm timeslot deletion #}
+  <div id="delete-modal" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">&times;</span>
+            <span class="sr-only">Close</span>
+          </button>
+          <h4 class="modal-title">Confirm Delete</h4>
+        </div>
+
+        <div class="modal-body">
+          <p>The following timeslot will be deleted:</p>
+          <dl class="dl-horizontal">
+            <dt>Name</dt><dd><span class="ts-name"></span></dd>
+            <dt>Date</dt><dd><span class="ts-date"></span></dd>
+            <dt>Time</dt><dd><span class="ts-time"></span></dd>
+            <dt>Location</dt><dd><span class="ts-location"></span></dd>
+          </dl>
+          <p class="unofficial-use-warning">
+            The official schedule will not be affected, but sessions in
+            unofficial schedules currently assigned to this timeslot
+            will become unassigned.
+          </p>
+          <p class="official-use-warning">
+            The official schedule will be affected.
+            Sessions currently assigned to this timeslot will become unassigned.
+          </p>
+          <p>Are you sure you want to delete this timeslot?</p>
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          <button type="button" id="confirm-delete-button" class="btn btn-primary" onclick="timeslotEdit.handleDeleteButtonClick()">Delete</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  </div>
+
 {% endblock %}
 
 {% block js %}
   <script type="text/javascript">
-  window.addEventListener('load', function (event) {
-    document.getElementById('timeslot-table').addEventListener('click', function(event) {
-      let clicked = event.target; // find out what was clicked
-      if (clicked.classList.contains('timeslot-delete-button')) {
-        // handle timeslot delete button click
-        let timeslotElt = clicked.closest('.timeslot');
-        let deleteId = timeslotElt.dataset.timeslotPk;
-        deleteTimeSlot(deleteId)
-        .error(function(jqXHR, textStatus) {
-          displayError('Error deleting timeslot: ' + jqXHR.responseText)
-        })
-        .done(function () {timeslotElt.parentNode.removeChild(timeslotElt)});
+  // create a namespace for local JS
+  timeslotEdit = (function() {
+    let deleteModal;
+
+    function initializeDeleteModal() {
+      deleteModal = jQuery('#delete-modal');
+      deleteModal.deletePk = null; // PK of TimeSlot that modal 'Delete' button should delete
+      deleteModal.elts = {
+        unofficialUseWarning: deleteModal.find('.unofficial-use-warning'),
+        officialUseWarning: deleteModal.find('.official-use-warning'),
+        timeslotNameSpans: deleteModal.find('span.ts-name'),
+        timeslotDateSpans: deleteModal.find('span.ts-date'),
+        timeslotTimeSpans: deleteModal.find('span.ts-time'),
+        timeslotLocSpans: deleteModal.find('span.ts-location')
+      };
+
+      document.getElementById('timeslot-table').addEventListener('click', function(event) {
+        let clicked = event.target; // find out what was clicked
+        if (clicked.classList.contains('timeslot-delete-button')) {
+          // handle timeslot delete button click
+          let timeslotElt = clicked.closest('.timeslot');
+          let unofficialUse = Boolean(timeslotElt.dataset.unofficialUse === 'true'); // is a session assigned in any schedule?
+          let officialUse = Boolean(timeslotElt.dataset.officialUse === 'true'); // is a session assigned in the official schedule?
+
+          deleteModal.elts.unofficialUseWarning.hide();
+          deleteModal.elts.officialUseWarning.hide();
+          deleteModal.elts.timeslotNameSpans.text(timeslotElt.dataset.timeslotName);
+          deleteModal.elts.timeslotDateSpans.text(timeslotElt.dataset.timeslotDate);
+          deleteModal.elts.timeslotTimeSpans.text(timeslotElt.dataset.timeslotTime);
+          deleteModal.elts.timeslotLocSpans.text(timeslotElt.dataset.timeslotLocation);
+          if (officialUse) {
+            deleteModal.elts.officialUseWarning.show();
+          } else if (unofficialUse) {
+            deleteModal.elts.unofficialUseWarning.show();
+          }
+
+          deleteModal.deletePk  = timeslotElt.dataset.timeslotPk;
+          deleteModal.modal('show');
+        }
+      });
+    }
+
+    // Update timeslot classes when DOM changes
+    function tstableObserveCallback(mutationList) {
+      mutationList.forEach(mutation => {
+        if (mutation.type === 'childList' && mutation.target.classList.contains('tscell')) {
+          const tscell = mutation.target;
+          // mark collisions
+          if (tscell.getElementsByClassName('timeslot').length > 1) {
+            tscell.classList.add('timeslot-collision');
+          } else {
+            tscell.classList.remove('timeslot-collision');
+          }
+
+          // remove timeslot type classes for any removed timeslots
+          mutation.removedNodes.forEach(node => {
+            if (node.classList.contains('timeslot') && node.dataset.timeslotType) {
+              tscell.classList.remove('tstype_' + node.dataset.timeslotType);
+            }
+          });
+
+          // now add timeslot type classes for any remaining timeslots
+          tscell.getElementsByClassName('timeslot').forEach(elt => {
+            if (elt.dataset.timeslotType) {
+              tscell.classList.add('tstype_' + elt.dataset.timeslotType);
+            }
+          });
+        }
+      });
+    }
+
+    function initializeTsTableObserver() {
+      const observer = new MutationObserver(tstableObserveCallback);
+      observer.observe(document.querySelector('#timeslot-table tbody'), { childList: true, subtree: true });
+    }
+
+    window.addEventListener('load', function (event) {
+      initializeTsTableObserver();
+      initializeDeleteModal();
+    });
+
+    function removeTimeslotElement(elt) {
+      if (elt.parentNode) {
+        elt.parentNode.removeChild(elt);
       }
-    })
-  });
+    }
+
+    function handleDeleteButtonClick() {
+      if (!deleteModal || !deleteModal.deletePk) {
+        return; // do nothing it not yet initialized
+      }
+
+      let timeslotElt = document.getElementById('timeslot' + String(deleteModal.deletePk));
+      deleteTimeSlot(deleteModal.deletePk)
+      .error(function(jqXHR, textStatus) {
+        displayError('Error deleting timeslot: ' + jqXHR.responseText)
+      })
+      .done(function () {timeslotElt.parentNode.removeChild(timeslotElt)})
+      .always(function () {deleteModal.modal('hide')});
+    }
 
     /**
      * Make an AJAX request to delete a TimeSlot

--- a/ietf/templates/meeting/timeslot_edit.html
+++ b/ietf/templates/meeting/timeslot_edit.html
@@ -10,8 +10,6 @@
   .tstable th { white-space: nowrap;}
   .tstable td { white-space: nowrap;}
   .capacity { font-size:80%; font-weight: normal;}
-
-  .tstable .tstype_unavail {background-color:#666;}
 {% endblock %}
 
 {% block content %}
@@ -20,6 +18,7 @@
   <p class="pull-right">
     <a href="{% url "ietf.meeting.views.create_timeslot" num=meeting.number %}">New timeslot</a>
   </p>
+  <div class="timeslot-edit">
   <table id="timeslot-table" class="tstable table table-striped table-compact table-bordered">
     <thead>
     <tr>
@@ -42,16 +41,22 @@
     </tr>
     </thead>
 
+    <tbody>
     {% for room in rooms %}
       <tr>
-        <th>{{room.name}}<span class='capacity'>{% if room.capacity %} ({{room.capacity}}){% endif %}</th>
+        <th>{{room.name}}{% if room.capacity %} <span class='capacity'>({{room.capacity}})</span>{% endif %}</th>
         {% for day in time_slices %}
-          {% for slice in date_slices|lookup:day %}
-            {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts_list.popleft only %}
-          {% endfor %}
+          {% for slice in date_slices|lookup:day %}{% with cell_ts=ts_list.popleft %}
+            <td class="tscell {% if cell_ts|length > 1 %}timeslot-collision {% endif %}{% for ts in cell_ts %}tstype_{{ ts.type.slug }} {% endfor %}">
+            {% for ts in cell_ts %}
+              {% include 'meeting/timeslot_edit_timeslot.html' with ts=ts in_use=ts_with_any_assignments in_official_use=ts_with_official_assignments only %}
+            {% endfor %}
+          {% endwith %}{% endfor %}
+          </td>
         {% endfor %}
       </tr>
     {% endfor %}
+    </tbody>
   </table>
 
 {% endblock %}
@@ -74,25 +79,31 @@
     })
   });
 
-  /**
-   * Make an AJAX request to delete a TimeSlot
-   *
-   * @param id ID of TimeSlot to delete
-   * @returns jqXHR object corresponding to jQuery ajax request
-   */
-  function deleteTimeSlot(id) {
-    return jQuery.ajax({
-      method: 'post',
-      timeout: 5 * 1000,
-      data: {
-        action: 'delete',
-        slot_id: String(id)
-      }
-    });
-  }
+    /**
+     * Make an AJAX request to delete a TimeSlot
+     *
+     * @param id ID of TimeSlot to delete
+     * @returns jqXHR object corresponding to jQuery ajax request
+     */
+    function deleteTimeSlot(id) {
+      return jQuery.ajax({
+        method: 'post',
+        timeout: 5 * 1000,
+        data: {
+          action: 'delete',
+          slot_id: String(id)
+        }
+      });
+    }
 
-  function displayError(msg) {
-    window.alert(msg);
-  }
+    function displayError(msg) {
+      window.alert(msg);
+    }
+
+    // export callable methods
+    return {
+      handleDeleteButtonClick: handleDeleteButtonClick,
+    }
+  })();
   </script>
 {% endblock %}

--- a/ietf/templates/meeting/timeslot_edit_timeslot.html
+++ b/ietf/templates/meeting/timeslot_edit_timeslot.html
@@ -1,14 +1,24 @@
-<td{% if ts %} class="tstype_{{ ts.type.slug }}"{% endif %}>
-  {% if ts %}
-    <div class="thumbnail timeslot" data-timeslot-pk="{{ ts.pk }}">
-    {{ ts.name }}
-      <!-- todo display timeslot type, number of sessions using it -->
-    <div class="pull-right">
-      <a href="{% url 'ietf.meeting.views.edit_timeslot' num=ts.meeting.number slot_id=ts.id %}">
-        <span class="fa fa-pencil-square-o"></span>
-      </a>
-        <span class="fa fa-trash timeslot-delete-button"></span>
-    </div>
-    </div>
-  {% endif %}
-</td>
+<div id="timeslot{{ ts.pk }}"
+     class="thumbnail timeslot {% if ts in in_official_use %}in-official-use{% elif ts in in_use %}in-unofficial-use{% endif %}"
+     data-timeslot-pk="{{ ts.pk }}"
+     data-timeslot-name="{{ ts.name }}"
+     data-timeslot-type="{{ ts.type.slug }}"
+     data-timeslot-location="{{ ts.location.name }}"
+     data-timeslot-date="{{ ts.time|date:"l (Y-m-d)" }}"
+     data-timeslot-time="{{ ts.time|date:"H:i" }}-{{ ts.end_time|date:"H:i" }}"
+     data-unofficial-use="{% if ts in in_use and ts not in in_official_use %}true{% else %}false{% endif %}"
+     data-official-use="{% if ts in in_official_use %}true{% else %}false{% endif %}">
+  <div class="ts-name">
+    <span
+      title="{% if ts in in_official_use %}Used in official schedule{% elif ts in in_use %}Used in unofficial schedule{% else %}Unused{% endif %}">
+      {{ ts.name }}
+    </span>
+  </div>
+  <div class="ts-type">{{ ts.type }}</div>
+  <div class="pull-right">
+    <a href="{% url 'ietf.meeting.views.edit_timeslot' num=ts.meeting.number slot_id=ts.id %}">
+      <span class="fa fa-pencil-square-o"></span>
+    </a>
+    <span class="fa fa-trash timeslot-delete-button" title="Delete this timeslot"></span>
+  </div>
+</div>

--- a/ietf/templates/meeting/timeslot_edit_timeslot.html
+++ b/ietf/templates/meeting/timeslot_edit_timeslot.html
@@ -1,5 +1,5 @@
 <div id="timeslot{{ ts.pk }}"
-     class="thumbnail timeslot {% if ts in in_official_use %}in-official-use{% elif ts in in_use %}in-unofficial-use{% endif %}"
+     class="timeslot {% if ts in in_official_use %}in-official-use{% elif ts in in_use %}in-unofficial-use{% endif %}"
      data-timeslot-pk="{{ ts.pk }}"
      data-date-id="{{ ts.time.date.isoformat }}"{# used for identifying day/col contents #}
      data-col-id="{{ ts.time.date.isoformat }}T{{ ts.time|date:"H:i" }}-{{ ts.end_time|date:"H:i" }}" {# used for identifying column contents #}
@@ -16,11 +16,11 @@
       {{ ts.name }}
     </span>
   </div>
-  <div class="ts-type">{{ ts.type }}</div>
-  <div class="pull-right">
+  <div class="timeslot-buttons">
     <a href="{% url 'ietf.meeting.views.edit_timeslot' num=ts.meeting.number slot_id=ts.id %}">
       <span class="fa fa-pencil-square-o"></span>
     </a>
     <span class="fa fa-trash delete-button" data-delete-scope="timeslot" title="Delete this timeslot"></span>
   </div>
+  <div class="ts-type">{{ ts.type }}</div>
 </div>

--- a/ietf/templates/meeting/timeslot_edit_timeslot.html
+++ b/ietf/templates/meeting/timeslot_edit_timeslot.html
@@ -1,6 +1,8 @@
 <div id="timeslot{{ ts.pk }}"
      class="thumbnail timeslot {% if ts in in_official_use %}in-official-use{% elif ts in in_use %}in-unofficial-use{% endif %}"
      data-timeslot-pk="{{ ts.pk }}"
+     data-date-id="{{ ts.time.date.isoformat }}"{# used for identifying day/col contents #}
+     data-col-id="{{ ts.time.date.isoformat }}T{{ ts.time|date:"H:i" }}-{{ ts.end_time|date:"H:i" }}" {# used for identifying column contents #}
      data-timeslot-name="{{ ts.name }}"
      data-timeslot-type="{{ ts.type.slug }}"
      data-timeslot-location="{{ ts.location.name }}"
@@ -19,6 +21,6 @@
     <a href="{% url 'ietf.meeting.views.edit_timeslot' num=ts.meeting.number slot_id=ts.id %}">
       <span class="fa fa-pencil-square-o"></span>
     </a>
-    <span class="fa fa-trash timeslot-delete-button" title="Delete this timeslot"></span>
+    <span class="fa fa-trash delete-button" data-delete-scope="timeslot" title="Delete this timeslot"></span>
   </div>
 </div>

--- a/ietf/templates/meeting/timeslot_edit_timeslot.html
+++ b/ietf/templates/meeting/timeslot_edit_timeslot.html
@@ -1,0 +1,14 @@
+<td{% if ts %} class="tstype_{{ ts.type.slug }}"{% endif %}>
+  {% if ts %}
+    <div class="thumbnail timeslot" data-timeslot-pk="{{ ts.pk }}">
+    {{ ts.name }}
+      <!-- todo display timeslot type, number of sessions using it -->
+    <div class="pull-right">
+      <a href="{% url 'ietf.meeting.views.edit_timeslot' num=ts.meeting.number slot_id=ts.id %}">
+        <span class="fa fa-pencil-square-o"></span>
+      </a>
+        <span class="fa fa-trash timeslot-delete-button"></span>
+    </div>
+    </div>
+  {% endif %}
+</td>


### PR DESCRIPTION
Addresses [Ticket 3127](https://trac.ietf.org/trac/ietfdb/ticket/3127) and is part of the process of replacing the secr app's meeting manager. Further work on and around this is expected.

This is the same as #26, but rebased to 7.38.0.

This adds a new timeslot edit page similar in style to the new meeting schedule editor. This is intended to replace the timeslot management in the secr app. Similar function is present in the the timeslot editor handled by the `ietf.meeting.views.edit_meeting_timeslots_and_misc_sessions` view. That view, tied to a meeting and a particular schedule, allows editing of timeslots, plus creation and manipulation of "misc sessions" which (I think) are a combination of a timeslot and session. Robert has indicated that the goal is to integrate editing these sorts of sessions with the main schedule editor, which makes this misc session approach unnecessary. 

This new editor deals only with timeslots and is tied only to a meeting. Compared to the `edit_meeting_timeslots_and_misc_sessions` view, it gives a simpler (and hopefully clearer) presentation. It allows creation of grids of similar timeslots en masse, filling in a set of dates and locations. This is intended to allow 'Session I' to be defined at the same time on all meeting days in all rooms, for example.

I've tried to leave a sensible development trail in the commit history.

The new work is centered on the `edit_timeslots()` view. This existed previously, allowing editing of timeslot type but nothing else. The basic structure of that display has been kept, though much has been added to it. Timeslots can be created or edited individually through the `create_timeslots()` and `edit_timeslot()` views. Deletion is handled via an AJAX call to the `edit_timeslots()` view to delete one or many timeslots.