### PR TITLE
Add purpose-based filters for individual sessions/series

### DIFF
--- a/ietf/templates/meeting/agenda_filter.html
+++ b/ietf/templates/meeting/agenda_filter.html
@@ -66,7 +66,7 @@ Optional parameters:
                                                     {% for button in p.children %}
                                                         <div class="btn-group btn-group-xs btn-group-justified">
                                                             <button class="btn btn-default pickview {{ button.keyword }}"
-                                                                    {% if p.keyword or button.is_bof %}data-filter-keywords="{% if p.keyword %}{{ p.keyword }}{% if button.is_bof %},{% endif %}{% endif %}{% if button.is_bof %}bof{% endif %}"{% endif %}
+                                                                    {% if button.toggled_by %}data-filter-keywords="{{ button.toggled_by|join:"," }}"{% endif %}
                                                                     data-filter-item="{{ button.keyword }}">
                                                                 {% if button.is_bof %}
                                                                     <i>{{ button.label }}</i>


### PR DESCRIPTION
This is the third part of the Ticket 3330 work. It refactors the office hours work from 3128 (#11) to work using the session purpose instead of timeslot type.

  * Replace `TimeSlotTypeName-based` filters with `SessionPurposeName`-based
  * Use slugified session name to identify purpose-based filters
    - sessions with the same name filter using the same keyword
  * Refactor `AgendaFilterTool` and subclasses
    - define helpers in the base class to ensure consistent keywording
    - turn `non_group_filter_*` into just `filter_*` as much as possible
    - make `group_filter_*` into specialized forms of `filter_*`
    - compute both `data-filter-keywords` and `data-filter-item` in the helper instead of template; names out of sync (`data-filter-keywords` is "tagged_by" and `data-filter-item` is "keyword", which should be resolved)
    - assign additional keywords so selection by group toggles the expected columns in the filter UI to show what is being displayed