### PR TITLE
Update "misc session" handling in the secr app to deal with Session.purpose

### DIFF
--- a/ietf/meeting/templatetags/agenda_custom_tags.py
+++ b/ietf/meeting/templatetags/agenda_custom_tags.py
@@ -74,9 +74,9 @@ def webcal_url(context, viewname, *args, **kwargs):
 @register.simple_tag
 def assignment_display_name(assignment):
     """Get name for an assignment"""
-    if assignment.slot_type().slug == 'regular' and assignment.session.historic_group:
+    if assignment.session.type.slug == 'session' and assignment.session.historic_group:
         return assignment.session.historic_group.name
-    return assignment.timeslot.name
+    return assignment.session.name or assignment.timeslot.name
 
 
 class AnchorNode(template.Node):

--- a/ietf/secr/meetings/views.py
+++ b/ietf/secr/meetings/views.py
@@ -537,7 +537,8 @@ def misc_session_edit(request, meeting_id, schedule_name, slot_id):
             name = form.cleaned_data['name']
             short = form.cleaned_data['short']
             duration = form.cleaned_data['duration']
-            slot_type = form.cleaned_data['type']
+            session_purpose = form.cleaned_data['purpose'].purpose
+            slot_type = form.cleaned_data['purpose'].type
             show_location = form.cleaned_data['show_location']
             remote_instructions = form.cleaned_data['remote_instructions']
             time = get_timeslot_time(form, meeting)
@@ -553,6 +554,8 @@ def misc_session_edit(request, meeting_id, schedule_name, slot_id):
             session.name = name
             session.short = short
             session.remote_instructions = remote_instructions
+            session.purpose = session_purpose
+            session.type = slot_type
             session.save()
 
             messages.success(request, 'Location saved')
@@ -570,7 +573,8 @@ def misc_session_edit(request, meeting_id, schedule_name, slot_id):
                    'time':slot.time.strftime('%H:%M'),
                    'duration':duration_string(slot.duration),
                    'show_location':slot.show_location,
-                   'type':slot.type,
+                   'purpose': session.purpose,
+                   'type': session.type,
                    'remote_instructions': session.remote_instructions,
                }
         form = MiscSessionForm(initial=initial, meeting=meeting, session=session)

--- a/ietf/secr/static/secr/js/session_purpose_and_type_widget.js
+++ b/ietf/secr/static/secr/js/session_purpose_and_type_widget.js
@@ -1,0 +1,83 @@
+/* Copyright The IETF Trust 2021, All Rights Reserved
+ *
+ * JS support for the SessionPurposeAndTypeWidget
+ * */
+(function() {
+  'use strict';
+
+  /* Find elements that are parts of the session details widgets. This is an
+  * HTMLCollection that will update if the DOM changes, so ok to evaluate immediately. */
+  const widget_elements = document.getElementsByClassName('session_purpose_widget');
+
+  /* Find the id prefix for each widget. Individual elements have a _<number> suffix. */
+  function get_widget_ids(elements) {
+    const ids = new Set();
+    for (let ii=0; ii < elements.length; ii++) {
+      const parts = elements[ii].id.split('_');
+      parts.pop();
+      ids.add(parts.join('_'));
+    }
+    return ids;
+  }
+
+  /* Set the 'type' element to a type valid for the currently selected purpose, if possible */
+  function set_valid_type(type_elt, purpose, allowed_types) {
+    const valid_types = allowed_types[purpose] || [];
+    if (valid_types.indexOf(type_elt.value) === -1) {
+      type_elt.value = (valid_types.length > 0) ? valid_types[0] : '';
+    }
+  }
+
+  /* Hide any type options not allowed for the selected purpose */
+  function update_type_option_visibility(type_option_elts, purpose, allowed_types) {
+    const valid_types = allowed_types[purpose] || [];
+    for (const elt of type_option_elts) {
+      if (valid_types.indexOf(elt.value) === -1) {
+        elt.setAttribute('hidden', 'hidden');
+      } else {
+        elt.removeAttribute('hidden');
+      }
+    }
+  }
+
+  /* Update visibility of 'type' select so it is only shown when multiple options are available */
+  function update_widget_visibility(elt, purpose, allowed_types) {
+    const valid_types = allowed_types[purpose] || [];
+    if (valid_types.length > 1) {
+      elt.removeAttribute('hidden'); // make visible
+    } else {
+      elt.setAttribute('hidden', 'hidden'); // make invisible
+    }
+  }
+
+  /* Update the 'type' select to reflect a change in the selected purpose */
+  function update_type_element(type_elt, purpose, type_options, allowed_types) {
+    update_widget_visibility(type_elt, purpose, allowed_types);
+    update_type_option_visibility(type_options, purpose, allowed_types);
+    set_valid_type(type_elt, purpose, allowed_types);
+  }
+
+  /* Factory for event handler with a closure */
+  function purpose_change_handler(type_elt, type_options, allowed_types) {
+    return function(event) {
+      update_type_element(type_elt, event.target.value, type_options, allowed_types);
+    };
+  }
+
+  /* Initialization */
+  function on_load() {
+    for (const widget_id of get_widget_ids(widget_elements)) {
+      const purpose_elt = document.getElementById(widget_id + '_0');
+      const type_elt = document.getElementById(widget_id + '_1');
+      const type_options = type_elt.getElementsByTagName('option');
+      const allowed_types = JSON.parse(type_elt.dataset.allowedOptions);
+
+      purpose_elt.addEventListener(
+        'change',
+        purpose_change_handler(type_elt, type_options, allowed_types)
+      );
+      update_type_element(type_elt, purpose_elt.value, type_options, allowed_types);
+    }
+  }
+  window.addEventListener('load', on_load, false);
+})();

--- a/ietf/secr/templates/meetings/misc_session_edit.html
+++ b/ietf/secr/templates/meetings/misc_session_edit.html
@@ -21,3 +21,11 @@
 </div> <!-- module -->
 
 {% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ form.media.js }}
+{% endblock %}
+{% block extrastyle %}
+  {{ form.media.css }}
+{% endblock %}

--- a/ietf/secr/templates/meetings/misc_sessions.html
+++ b/ietf/secr/templates/meetings/misc_sessions.html
@@ -1,5 +1,5 @@
 {% extends "meetings/base_rooms_times.html" %}
-
+{% load agenda_custom_tags %}
 {% block subsection %}
 
 <div class="module">
@@ -27,12 +27,12 @@
           <tr class="{% cycle 'row1' 'row2' %}{% ifchanged assignment.session.type %} break{% endifchanged %}{% if assignment.current_session_status == "canceled" %} cancelled{% endif %}">
             <td>{{ assignment.timeslot.time|date:"D" }}</td>
             <td>{{ assignment.timeslot.time|date:"H:i" }}-{{ assignment.timeslot.end_time|date:"H:i" }}</td>
-            <td>{{ assignment.timeslot.name }}</td>
+            <td>{% assignment_display_name assignment %}</td>
             <td>{{ assignment.session.short }}</td>
             <td>{{ assignment.session.group.acronym }}</td>
             <td>{{ assignment.timeslot.location }}</td>
             <td>{{ assignment.timeslot.show_location }}</td>
-            <td>{{ assignment.slot_type }}</td>
+            <td>{% with purpose=assignment.session.purpose %}{{ purpose }}{% if purpose.timeslot_types|length > 1 %} ({{ assignment.slot_type }}){% endif %}{% endwith %}</td>
             {% if assignment.schedule_id == schedule.pk %}
               <td><a href="{% url "ietf.secr.meetings.views.misc_session_edit" meeting_id=meeting.number schedule_name=schedule.name slot_id=assignment.timeslot.id %}">Edit</a></td>
               <td>
@@ -73,4 +73,12 @@
 </div> <!-- module -->
 
 
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ form.media.js }}
+{% endblock %}
+{% block extrastyle %}
+  {{ form.media.css }}
 {% endblock %}

--- a/ietf/templates/meeting/agenda_filter.html
+++ b/ietf/templates/meeting/agenda_filter.html
@@ -66,7 +66,7 @@ Optional parameters:
                                                     {% for button in p.children %}
                                                         <div class="btn-group btn-group-xs btn-group-justified">
                                                             <button class="btn btn-default pickview {{ button.keyword }}"
-                                                                    {% if p.keyword or button.is_bof %}data-filter-keywords="{% if p.keyword %}{{ p.keyword }}{% if button.is_bof %},{% endif %}{% endif %}{% if button.is_bof %}bof{% endif %}"{% endif %}
+                                                                    {% if button.toggled_by %}data-filter-keywords="{{ button.toggled_by|join:"," }}"{% endif %}
                                                                     data-filter-item="{{ button.keyword }}">
                                                                 {% if button.is_bof %}
                                                                     <i>{{ button.label }}</i>


### PR DESCRIPTION
This adds a widget to coordinate setting valid combinations of Session type and purpose, then uses it to create and edit "misc" sessions in the secr app. These sessions are represented by a combination of a Session and a TimeSlot.

This pull request includes #63 as well - feel free to review them together or separately.