### PR TITLE
Prevent tests from using "real" filesystem

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -5,7 +5,6 @@
 import json
 import html
 import os
-import shutil
 import sys
 
 from importlib import import_module
@@ -38,14 +37,7 @@ OMITTED_APPS = (
 )
 
 class CustomApiTests(TestCase):
-    def setUp(self):
-        self.agenda_path = self.tempdir('materials')
-        self.saved_agenda_path = settings.AGENDA_PATH
-        settings.AGENDA_PATH = self.agenda_path
-
-    def tearDown(self):
-        shutil.rmtree(self.agenda_path)
-        settings.AGENDA_PATH = self.saved_agenda_path
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['AGENDA_PATH']
 
     # Using mock to patch the import functions in ietf.meeting.views, where
     # api_import_recordings() are using them:

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1056,6 +1056,7 @@ class DeferUndeferTestCase(TestCase):
     # when charters support being deferred, be sure to test them here
 
     def setUp(self):
+        super().setUp()
         IndividualDraftFactory(name='draft-ietf-mars-test',states=[('draft','active'),('draft-iesg','iesg-eva')],
                                ad=Person.objects.get(user__username='ad'))
         DocumentFactory(type_id='statchg',name='status-change-imaginary-mid-review',states=[('statchg','iesgeval')])

--- a/ietf/doc/tests_bofreq.py
+++ b/ietf/doc/tests_bofreq.py
@@ -2,10 +2,9 @@
 
 import datetime
 import debug    # pyflakes:ignore
-import io
 import os
-import shutil
 
+from pathlib import Path
 from pyquery import PyQuery
 from random import randint
 from tempfile import NamedTemporaryFile
@@ -24,19 +23,11 @@ from ietf.utils.test_utils import TestCase, reload_db_objects, unicontent, login
 
 
 class BofreqTests(TestCase):
-
-    def setUp(self):
-        self.bofreq_dir = self.tempdir('bofreq')
-        self.saved_bofreq_path = settings.BOFREQ_PATH
-        settings.BOFREQ_PATH = self.bofreq_dir
-
-    def tearDown(self):
-        settings.BOFREQ_PATH = self.saved_bofreq_path
-        shutil.rmtree(self.bofreq_dir)
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['BOFREQ_PATH']
 
     def write_bofreq_file(self, bofreq):
-        fname = os.path.join(self.bofreq_dir, "%s-%s.md" % (bofreq.canonical_name(), bofreq.rev))
-        with io.open(fname, "w") as f:
+        fname = Path(settings.BOFREQ_PATH) / ("%s-%s.md" % (bofreq.canonical_name(), bofreq.rev))
+        with fname.open("w") as f:
             f.write(f"""# This is a test bofreq.
 Version: {bofreq.rev}
 

--- a/ietf/doc/tests_conflict_review.py
+++ b/ietf/doc/tests_conflict_review.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import shutil
 
 from pyquery import PyQuery
 from textwrap import wrap
@@ -367,11 +366,13 @@ class ConflictReviewTests(TestCase):
         self.assertEqual(len(outbox), 0)
 
     def setUp(self):
+        super().setUp()
         IndividualDraftFactory(name='draft-imaginary-independent-submission')
         ConflictReviewFactory(name='conflict-review-imaginary-irtf-submission',review_of=IndividualDraftFactory(name='draft-imaginary-irtf-submission',stream_id='irtf'),notify='notifyme@example.net')
 
 
 class ConflictReviewSubmitTests(TestCase):
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['CONFLICT_REVIEW_PATH']
     def test_initial_submission(self):
         doc = Document.objects.get(name='conflict-review-imaginary-irtf-submission')
         url = urlreverse('ietf.doc.views_conflict_review.submit',kwargs=dict(name=doc.name))
@@ -447,11 +448,5 @@ class ConflictReviewSubmitTests(TestCase):
         self.assertTrue(q('textarea')[0].text.strip().startswith("[Edit this page"))
         
     def setUp(self):
+        super().setUp()
         ConflictReviewFactory(name='conflict-review-imaginary-irtf-submission',review_of=IndividualDraftFactory(name='draft-imaginary-irtf-submission',stream_id='irtf'),notify='notifyme@example.net')
-        self.test_dir = self.tempdir('conflict-review')
-        self.saved_conflict_review_path = settings.CONFLICT_REVIEW_PATH
-        settings.CONFLICT_REVIEW_PATH = self.test_dir
-
-    def tearDown(self):
-        settings.CONFLICT_REVIEW_PATH = self.saved_conflict_review_path
-        shutil.rmtree(self.test_dir)

--- a/ietf/doc/tests_downref.py
+++ b/ietf/doc/tests_downref.py
@@ -16,6 +16,7 @@ from ietf.utils.test_utils import login_testing_unauthorized
 class Downref(TestCase):
 
     def setUp(self):
+        super().setUp()
         PersonFactory(name='Plain Man',user__username='plain')
         self.draft = WgDraftFactory(name='draft-ietf-mars-test')
         self.draftalias = self.draft.docalias.get(name='draft-ietf-mars-test')

--- a/ietf/doc/tests_irsg_ballot.py
+++ b/ietf/doc/tests_irsg_ballot.py
@@ -424,12 +424,14 @@ class BaseManipulationTests():
 class IRTFChairTests(BaseManipulationTests, TestCase):
 
     def setUp(self):
+        super().setUp()
         self.username = 'irtf-chair'
         self.balloter = ''
 
 class SecretariatTests(BaseManipulationTests, TestCase):
 
     def setUp(self):
+        super().setUp()
         self.username = 'secretary'
         self.balloter = '?balloter={}'.format(Person.objects.get(user__username='irtf-chair').pk)
 
@@ -437,6 +439,7 @@ class SecretariatTests(BaseManipulationTests, TestCase):
 class IRSGMemberTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.username = get_active_irsg()[0].user.username
 
     def test_cant_issue_irsg_ballot(self):

--- a/ietf/doc/tests_material.py
+++ b/ietf/doc/tests_material.py
@@ -7,6 +7,7 @@ import shutil
 import datetime
 import io
 
+from pathlib import Path
 from pyquery import PyQuery
 
 import debug              # pyflakes:ignore
@@ -25,26 +26,24 @@ from ietf.utils.test_utils import TestCase, login_testing_unauthorized
 
 
 class GroupMaterialTests(TestCase):
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['AGENDA_PATH']
     def setUp(self):
+        super().setUp()
         self.materials_dir = self.tempdir("materials")
-        self.slides_dir = os.path.join(self.materials_dir, "slides")
-        if not os.path.exists(self.slides_dir):
-            os.mkdir(self.slides_dir)
+        self.slides_dir = Path(self.materials_dir) / "slides"
+        if not self.slides_dir.exists():
+            self.slides_dir.mkdir()
         self.saved_document_path_pattern = settings.DOCUMENT_PATH_PATTERN
         settings.DOCUMENT_PATH_PATTERN = self.materials_dir + "/{doc.type_id}/"
 
-        self.agenda_dir = self.tempdir("agenda")
-        self.meeting_slides_dir = os.path.join(self.agenda_dir, "42", "slides")
-        if not os.path.exists(self.meeting_slides_dir):
-            os.makedirs(self.meeting_slides_dir)
-        self.saved_agenda_path = settings.AGENDA_PATH
-        settings.AGENDA_PATH = self.agenda_dir
+        self.meeting_slides_dir = Path(settings.AGENDA_PATH) / "42" / "slides"
+        if not self.meeting_slides_dir.exists():
+            self.meeting_slides_dir.mkdir(parents=True)
 
     def tearDown(self):
         settings.DOCUMENT_PATH_PATTERN = self.saved_document_path_pattern
         shutil.rmtree(self.materials_dir)
-        settings.AGENDA_PATH = self.saved_agenda_path
-        shutil.rmtree(self.agenda_dir)
+        super().tearDown()
 
     def create_slides(self):
 

--- a/ietf/doc/tests_review.py
+++ b/ietf/doc/tests_review.py
@@ -41,6 +41,7 @@ from ietf.utils.text import strip_prefix, xslugify
 
 class ReviewTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.review_dir = self.tempdir('review')
         self.old_document_path_pattern = settings.DOCUMENT_PATH_PATTERN
         settings.DOCUMENT_PATH_PATTERN = self.review_dir + "/{doc.type_id}/"
@@ -52,6 +53,7 @@ class ReviewTests(TestCase):
     def tearDown(self):
         shutil.rmtree(self.review_dir)
         settings.DOCUMENT_PATH_PATTERN = self.old_document_path_pattern
+        super().tearDown()
 
     def test_request_review(self):
         doc = WgDraftFactory(group__acronym='mars',rev='01')

--- a/ietf/doc/tests_status_change.py
+++ b/ietf/doc/tests_status_change.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import shutil
 
 import debug    # pyflakes:ignore
 
@@ -441,12 +440,14 @@ class StatusChangeTests(TestCase):
         self.assertTrue(doc.latest_event(DocEvent,type="added_comment").desc.startswith('Affected RFC list changed.'))       
         
     def setUp(self):
+        super().setUp()
         IndividualRfcFactory(alias2__name='rfc14',name='draft-was-never-issued',std_level_id='unkn')
         WgRfcFactory(alias2__name='rfc9999',name='draft-ietf-random-thing',std_level_id='ps')
         WgRfcFactory(alias2__name='rfc9998',name='draft-ietf-random-other-thing',std_level_id='inf')
         DocumentFactory(type_id='statchg',name='status-change-imaginary-mid-review',notify='notify@example.org')
 
 class StatusChangeSubmitTests(TestCase):
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['STATUS_CHANGE_PATH']
     def test_initial_submission(self):
         doc = Document.objects.get(name='status-change-imaginary-mid-review')
         url = urlreverse('ietf.doc.views_status_change.submit',kwargs=dict(name=doc.name))
@@ -532,11 +533,5 @@ class StatusChangeSubmitTests(TestCase):
         self.assertContains(r, "This is the old proposal.")
 
     def setUp(self):
+        super().setUp()
         DocumentFactory(type_id='statchg',name='status-change-imaginary-mid-review',notify='notify@example.org')
-        self.test_dir = self.tempdir('status-change')
-        self.saved_status_change_path = settings.STATUS_CHANGE_PATH
-        settings.STATUS_CHANGE_PATH = self.test_dir
-
-    def tearDown(self):
-        settings.STATUS_CHANGE_PATH = self.saved_status_change_path
-        shutil.rmtree(self.test_dir)

--- a/ietf/doc/tests_utils.py
+++ b/ietf/doc/tests_utils.py
@@ -17,6 +17,7 @@ class ActionHoldersTests(TestCase):
 
     def setUp(self):
         """Set up helper for the update_action_holders tests"""
+        super().setUp()
         self.authors = PersonFactory.create_batch(3)
         self.ad = Person.objects.get(user__username='ad')
         self.group = GroupFactory()

--- a/ietf/group/tests.py
+++ b/ietf/group/tests.py
@@ -76,6 +76,7 @@ class StreamTests(TestCase):
 class GroupDocDependencyGraphTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         set_coverage_checking(False)
         a = WgDraftFactory()
         b = WgDraftFactory()
@@ -83,6 +84,7 @@ class GroupDocDependencyGraphTests(TestCase):
 
     def tearDown(self):
         set_coverage_checking(True)
+        super().tearDown()
 
     def test_group_document_dependency_dotfile(self):
         for group in Group.objects.filter(Q(type="wg") | Q(type="rg")):
@@ -123,6 +125,7 @@ class GroupDocDependencyGraphTests(TestCase):
 
 class GenerateGroupAliasesTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.doc_aliases_file = NamedTemporaryFile(delete=False, mode='w+')
         self.doc_aliases_file.close()
         self.doc_virtual_file = NamedTemporaryFile(delete=False, mode='w+')
@@ -137,6 +140,7 @@ class GenerateGroupAliasesTests(TestCase):
         settings.GROUP_VIRTUAL_PATH = self.saved_draft_virtual_path
         os.unlink(self.doc_aliases_file.name)
         os.unlink(self.doc_virtual_file.name)
+        super().tearDown()
 
     def testManagementCommand(self):
         a_month_ago = datetime.datetime.now() - datetime.timedelta(30)
@@ -237,6 +241,7 @@ class GenerateGroupAliasesTests(TestCase):
 class GroupRoleEmailTests(TestCase):
     
     def setUp(self):
+        super().setUp()
         # make_immutable_base_data makes two areas, and puts a group in one of them
         # the tests below assume all areas have groups
         for area in Group.objects.filter(type_id='area'):

--- a/ietf/idindex/tests.py
+++ b/ietf/idindex/tests.py
@@ -3,9 +3,8 @@
 
 
 import datetime
-import io
-import os
-import shutil
+
+from pathlib import Path
 
 from django.conf import settings
 
@@ -20,17 +19,8 @@ from ietf.person.factories import PersonFactory, EmailFactory
 from ietf.utils.test_utils import TestCase
 
 class IndexTests(TestCase):
-    def setUp(self):
-        self.id_dir = self.tempdir('id')
-        self.saved_internet_draft_path = settings.INTERNET_DRAFT_PATH
-        settings.INTERNET_DRAFT_PATH = self.id_dir
-
-    def tearDown(self):
-        settings.INTERNET_DRAFT_PATH = self.saved_internet_draft_path
-        shutil.rmtree(self.id_dir)
-        
     def write_draft_file(self, name, size):
-        with io.open(os.path.join(self.id_dir, name), 'w') as f:
+        with (Path(settings.INTERNET_DRAFT_PATH) / name).open('w') as f:
             f.write("a" * size)
 
     def test_all_id_txt(self):

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -58,6 +58,7 @@ else:
 
 class IetfAuthTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.saved_use_python_htdigest = getattr(settings, "USE_PYTHON_HTDIGEST", None)
         settings.USE_PYTHON_HTDIGEST = True
 
@@ -74,6 +75,7 @@ class IetfAuthTests(TestCase):
         settings.USE_PYTHON_HTDIGEST = self.saved_use_python_htdigest
         settings.HTPASSWD_FILE = self.saved_htpasswd_file
         settings.HTDIGEST_REALM = self.saved_htdigest_realm
+        super().tearDown()
 
     def test_index(self):
         self.assertEqual(self.client.get(urlreverse(ietf.ietfauth.views.index)).status_code, 200)

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -44,12 +44,6 @@ def make_data_from_content(content):
     return data
 
 class IprTests(TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-    
     def test_get_genitive(self):
         self.assertEqual(get_genitive("Cisco"),"Cisco's")
         self.assertEqual(get_genitive("Ross"),"Ross'")

--- a/ietf/liaisons/tests.py
+++ b/ietf/liaisons/tests.py
@@ -4,10 +4,10 @@
 
 import datetime
 import io
-import os
-import shutil
 
 import debug    # pyflakes:ignore
+
+from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -260,14 +260,7 @@ class ManagementCommandTests(TestCase):
 
 
 class LiaisonManagementTests(TestCase):
-    def setUp(self):
-        self.saved_liaison_attach_path = settings.LIAISON_ATTACH_PATH
-        self.liaison_dir = self.tempdir('liaison')
-        settings.LIAISON_ATTACH_PATH = self.liaison_dir
-
-    def tearDown(self):
-        settings.LIAISON_ATTACH_PATH = self.saved_liaison_attach_path
-        shutil.rmtree(self.liaison_dir)
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['LIAISON_ATTACH_PATH']
 
     def test_add_restrictions(self):
         # incoming restrictions
@@ -443,7 +436,7 @@ class LiaisonManagementTests(TestCase):
         self.assertEqual(new_liaison.attachments.count(), attachments_before + 1)
         attachment = new_liaison.attachments.order_by("-name")[0]
         self.assertEqual(attachment.title, "attachment")
-        with io.open(os.path.join(self.liaison_dir, attachment.uploaded_filename)) as f:
+        with (Path(settings.LIAISON_ATTACH_PATH) / attachment.uploaded_filename).open() as f:
             written_content = f.read()
 
         test_file.seek(0)
@@ -747,7 +740,7 @@ class LiaisonManagementTests(TestCase):
         self.assertEqual(l.attachments.count(), 1)
         attachment = l.attachments.all()[0]
         self.assertEqual(attachment.title, "attachment")
-        with io.open(os.path.join(self.liaison_dir, attachment.uploaded_filename)) as f:
+        with (Path(settings.LIAISON_ATTACH_PATH) / attachment.uploaded_filename).open() as f:
             written_content = f.read()
 
         test_file.seek(0)
@@ -826,7 +819,7 @@ class LiaisonManagementTests(TestCase):
         self.assertEqual(l.attachments.count(), 1)
         attachment = l.attachments.all()[0]
         self.assertEqual(attachment.title, "attachment")
-        with io.open(os.path.join(self.liaison_dir, attachment.uploaded_filename)) as f:
+        with (Path(settings.LIAISON_ATTACH_PATH) / attachment.uploaded_filename).open() as f:
             written_content = f.read()
 
         test_file.seek(0)

--- a/ietf/mailtrigger/test_utils.py
+++ b/ietf/mailtrigger/test_utils.py
@@ -10,6 +10,7 @@ from ietf.utils.test_utils import TestCase
 
 class GatherAddressListsTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.doc = WgDraftFactory(group__acronym='mars', rev='01')
         self.author_address = self.doc.name + '@ietf.org'
 

--- a/ietf/meeting/tests_schedule_generator.py
+++ b/ietf/meeting/tests_schedule_generator.py
@@ -18,6 +18,7 @@ import debug                            # pyflakes:ignore
 
 class ScheduleGeneratorTest(TestCase):
     def setUp(self):
+        super().setUp()
         # Create a meeting of 2 days, 5 sessions per day, in 2 rooms. There are 3 days
         # actually created, but sundays are ignored.
         # Two rooms is a fairly low level of simultaneous schedules, this is needed

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -76,6 +76,7 @@ class NomcomViewsTest(TestCase):
         return response
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         nomcom_test_data()
         self.cert_file, self.privatekey_file = get_cert_files()
@@ -107,6 +108,7 @@ class NomcomViewsTest(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def access_member_url(self, url):
         login_testing_unauthorized(self, COMMUNITY_USER, url)
@@ -954,12 +956,14 @@ class NomineePositionStateSaveTest(TestCase):
     """Tests for the NomineePosition save override method"""
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         nomcom_test_data()
         self.nominee = Nominee.objects.get(email__person__user__username=COMMUNITY_USER)
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_state_autoset(self):
         """Verify state is autoset correctly"""
@@ -989,6 +993,7 @@ class NomineePositionStateSaveTest(TestCase):
 class FeedbackTest(TestCase):
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
 
         nomcom_test_data()
@@ -996,6 +1001,7 @@ class FeedbackTest(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_encrypted_comments(self):
 
@@ -1022,6 +1028,7 @@ class FeedbackTest(TestCase):
 class ReminderTest(TestCase):
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         nomcom_test_data()
         self.nomcom = get_nomcom_by_year(NOMCOM_YEAR)
@@ -1065,6 +1072,7 @@ class ReminderTest(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_is_time_to_send(self):
         self.nomcom.reminder_interval = 4
@@ -1120,6 +1128,7 @@ class ReminderTest(TestCase):
 class InactiveNomcomTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         self.nc = NomComFactory.create(**nomcom_kwargs_for_year(group__state_id='conclude'))
         self.plain_person = PersonFactory.create()
@@ -1128,6 +1137,7 @@ class InactiveNomcomTests(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_feedback_closed(self):
         for view in ['ietf.nomcom.views.public_feedback', 'ietf.nomcom.views.private_feedback']:
@@ -1314,6 +1324,7 @@ class InactiveNomcomTests(TestCase):
 class FeedbackLastSeenTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         self.nc = NomComFactory.create(**nomcom_kwargs_for_year())
         self.author = PersonFactory.create().email_set.first().address
@@ -1334,6 +1345,7 @@ class FeedbackLastSeenTests(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_feedback_index_badges(self):
         url = reverse('ietf.nomcom.views.view_feedback',kwargs={'year':self.nc.year()})
@@ -1420,6 +1432,7 @@ class FeedbackLastSeenTests(TestCase):
 class NewActiveNomComTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         self.nc = NomComFactory.create(**nomcom_kwargs_for_year())
         self.chair = self.nc.group.role_set.filter(name='chair').first().person
@@ -1428,6 +1441,7 @@ class NewActiveNomComTests(TestCase):
     def tearDown(self):
         teardown_test_public_keys_dir(self)
         settings.DAYS_TO_EXPIRE_NOMINATION_LINK = self.saved_days_to_expire_nomination_link
+        super().tearDown()
 
     def test_help(self):
         url = reverse('ietf.nomcom.views.configuration_help',kwargs={'year':self.nc.year()})
@@ -1875,6 +1889,7 @@ Junk body for testing
 
 class NomComIndexTests(TestCase):
     def setUp(self):
+        super().setUp()
         for year in range(2000,2014):
             NomComFactory.create(**nomcom_kwargs_for_year(year=year,populate_positions=False,populate_personnel=False))
 
@@ -1885,6 +1900,7 @@ class NomComIndexTests(TestCase):
 
 class NoPublicKeyTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.nc = NomComFactory.create(**nomcom_kwargs_for_year(public_key=None))
         self.chair = self.nc.group.role_set.filter(name='chair').first().person
 
@@ -1914,6 +1930,7 @@ class NoPublicKeyTests(TestCase):
         
 class AcceptingTests(TestCase):
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         self.nc = NomComFactory(**nomcom_kwargs_for_year())
         self.plain_person = PersonFactory.create()
@@ -1921,6 +1938,7 @@ class AcceptingTests(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_public_accepting_nominations(self):
         url = reverse('ietf.nomcom.views.public_nominate',kwargs={'year':self.nc.year()})
@@ -2021,12 +2039,14 @@ class AcceptingTests(TestCase):
 
 class ShowNomineeTests(TestCase):
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         self.nc = NomComFactory(**nomcom_kwargs_for_year())
         self.plain_person = PersonFactory.create()
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
+        super().tearDown()
 
     def test_feedback_pictures(self):
         url = reverse('ietf.nomcom.views.public_nominate',kwargs={'year':self.nc.year()})
@@ -2042,6 +2062,7 @@ class ShowNomineeTests(TestCase):
 
 class TopicTests(TestCase):
     def setUp(self):
+        super().setUp()
         setup_test_public_keys_dir(self)
         self.nc = NomComFactory(**nomcom_kwargs_for_year(populate_topics=False))
         self.plain_person = PersonFactory.create()
@@ -2049,7 +2070,8 @@ class TopicTests(TestCase):
 
     def tearDown(self):
         teardown_test_public_keys_dir(self)
-    
+        super().tearDown()
+
     def testAddEditListRemoveTopic(self):
         self.assertFalse(self.nc.topic_set.exists())
 
@@ -2192,6 +2214,7 @@ class EligibilityUnitTests(TestCase):
 class rfc8713EligibilityTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.nomcom = NomComFactory(group__acronym='nomcom2019', populate_personnel=False, first_call_for_volunteers=datetime.date(2019,5,1))
 
         meetings = [ MeetingFactory(date=date,type_id='ietf') for date in (
@@ -2249,6 +2272,7 @@ class rfc8713EligibilityTests(TestCase):
 class rfc8788EligibilityTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.nomcom = NomComFactory(group__acronym='nomcom2020', populate_personnel=False, first_call_for_volunteers=datetime.date(2020,5,1))
 
         meetings = [MeetingFactory(number=number, date=date, type_id='ietf') for number,date in [
@@ -2286,6 +2310,7 @@ class rfc8788EligibilityTests(TestCase):
 class rfc8989EligibilityTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.nomcom = NomComFactory(group__acronym='nomcom2021', populate_personnel=False, first_call_for_volunteers=datetime.date(2021,5,15))
         # make_immutable_test_data makes things this test does not want
         Role.objects.filter(name_id__in=('chair','secr')).delete()

--- a/ietf/review/tests_policies.py
+++ b/ietf/review/tests_policies.py
@@ -76,7 +76,8 @@ class _Wrapper(TestCase):
         reviewer_queue_policy_id = ''
 
         def setUp(self):
-            self.team = ReviewTeamFactory(acronym="rotationteam", 
+            super().setUp()
+            self.team = ReviewTeamFactory(acronym="rotationteam",
                                           name="Review Team",
                                           list_email="rotationteam@ietf.org", 
                                           parent=Group.objects.get(acronym="farfut"))

--- a/ietf/secr/announcement/tests.py
+++ b/ietf/secr/announcement/tests.py
@@ -23,6 +23,7 @@ AD_USER=''
 
 class SecrAnnouncementTestCase(TestCase):
     def setUp(self):
+        super().setUp()
         chair = RoleName.objects.get(slug='chair')
         secr = RoleName.objects.get(slug='secr')
         ietf = Group.objects.get(acronym='ietf')

--- a/ietf/secr/proceedings/tests.py
+++ b/ietf/secr/proceedings/tests.py
@@ -6,7 +6,6 @@ import debug                            # pyflakes:ignore
 import io
 import json
 import os
-import shutil
 
 from django.conf import settings
 from django.urls import reverse
@@ -65,14 +64,7 @@ class VideoRecordingTestCase(TestCase):
         self.assertEqual(urls[0]['url'],'https://www.youtube.com/watch?v=lhYWB5FFkg4&list=PLC86T-6ZTP5jo6kIuqdyeYYhsKv9sUwG1')
         
 class RecordingTestCase(TestCase):
-    def setUp(self):
-        self.meeting_recordings_dir = self.tempdir('meeting-recordings')
-        self.saved_meeting_recordings_dir = settings.MEETING_RECORDINGS_DIR
-        settings.MEETING_RECORDINGS_DIR = self.meeting_recordings_dir
-
-    def tearDown(self):
-        shutil.rmtree(self.meeting_recordings_dir)
-        settings.MEETING_RECORDINGS_DIR = self.saved_meeting_recordings_dir
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['MEETING_RECORDINGS_DIR']
 
     def test_page(self):
         meeting = MeetingFactory(type_id='ietf')

--- a/ietf/secr/roles/tests.py
+++ b/ietf/secr/roles/tests.py
@@ -15,6 +15,7 @@ SECR_USER='secretary'
 class SecrRolesMainTestCase(TestCase):
 
     def setUp(self):
+        super().setUp()
         GroupFactory(type_id='sdo') # need this for the RoleForm initialization
 
     def test_main(self):

--- a/ietf/secr/sreq/tests.py
+++ b/ietf/secr/sreq/tests.py
@@ -456,6 +456,7 @@ class SubmitRequestCase(TestCase):
 
 class LockAppTestCase(TestCase):
     def setUp(self):
+        super().setUp()
         self.meeting = MeetingFactory(type_id='ietf', date=datetime.date.today(),session_request_lock_message='locked')
         self.group = GroupFactory(acronym='mars')
         RoleFactory(name_id='chair', group=self.group, person__user__username='marschairman')
@@ -531,6 +532,7 @@ class RetrievePreviousCase(TestCase):
 
 class SessionFormTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.meeting = MeetingFactory(type_id='ietf')
         self.group1 = GroupFactory()
         self.group2 = GroupFactory()

--- a/ietf/sync/tests.py
+++ b/ietf/sync/tests.py
@@ -7,7 +7,6 @@ import io
 import json
 import datetime
 import quopri
-import shutil
 
 from django.conf import settings
 from django.urls import reverse as urlreverse
@@ -219,22 +218,8 @@ ICANN
         
 
 class RFCSyncTests(TestCase):
-    def setUp(self):
-        self.save_id_dir = settings.INTERNET_DRAFT_PATH
-        self.save_archive_dir = settings.INTERNET_DRAFT_ARCHIVE_DIR
-        self.id_dir = self.tempdir('id')
-        self.archive_dir = self.tempdir('id-archive')
-        settings.INTERNET_DRAFT_PATH = self.id_dir
-        settings.INTERNET_DRAFT_ARCHIVE_DIR = self.archive_dir
-
-    def tearDown(self):
-        shutil.rmtree(self.id_dir)
-        shutil.rmtree(self.archive_dir)
-        settings.INTERNET_DRAFT_PATH = self.save_id_dir
-        settings.INTERNET_DRAFT_ARCHIVE_DIR = self.save_archive_dir
-
     def write_draft_file(self, name, size):
-        with io.open(os.path.join(self.id_dir, name), 'w') as f:
+        with io.open(os.path.join(settings.INTERNET_DRAFT_PATH, name), 'w') as f:
             f.write("a" * size)
 
     def test_rfc_index(self):
@@ -382,8 +367,8 @@ class RFCSyncTests(TestCase):
         self.assertEqual(doc.get_state_slug("draft-stream-ise"), "pub")
         self.assertEqual(doc.std_level_id, "ps")
         self.assertEqual(doc.pages, 42)
-        self.assertTrue(not os.path.exists(os.path.join(self.id_dir, draft_filename)))
-        self.assertTrue(os.path.exists(os.path.join(self.archive_dir, draft_filename)))
+        self.assertTrue(not os.path.exists(os.path.join(settings.INTERNET_DRAFT_PATH, draft_filename)))
+        self.assertTrue(os.path.exists(os.path.join(settings.INTERNET_DRAFT_ARCHIVE_DIR, draft_filename)))
 
         # make sure we can apply it again with no changes
         changed = list(rfceditor.update_docs_from_rfc_index(data, errata, today - datetime.timedelta(days=30)))

--- a/ietf/utils/test_utils.py
+++ b/ietf/utils/test_utils.py
@@ -38,6 +38,7 @@ import os
 import re
 import email
 import html5lib
+import shutil
 import sys
 
 from urllib.parse import unquote
@@ -139,9 +140,27 @@ class ReverseLazyTest(django.test.TestCase):
         self.assertRedirects(response, "/ipr/", status_code=301)
 
 class TestCase(django.test.TestCase):
+    """IETF TestCase class
+
+    Based on django.test.TestCase, but adds a few things:
+      * asserts for html5 validation.
+      * tempdir() convenience method
+      * setUp() and tearDown() that override settings paths with temp directories
+
+    The setUp() and tearDown() methods create / remove temporary paths and override
+    Django's settings with the temp dir names. Subclasses of this class must
+    be sure to call the superclass methods if they are overridden. These are created
+    anew for each test to avoid risk of cross-talk between test cases. Overriding
+    the settings_temp_path_overrides class value will modify which path settings are
+    replaced with temp test dirs.
     """
-    Does basically the same as django.test.TestCase, but adds asserts for html5 validation.
-    """
+    # These settings will be overridden with empty temporary directories
+    settings_temp_path_overrides = [
+        'RFC_PATH',
+        'INTERNET_ALL_DRAFTS_ARCHIVE_DIR',
+        'INTERNET_DRAFT_ARCHIVE_DIR',
+        'INTERNET_DRAFT_PATH',
+    ]
 
     parser = html5lib.HTMLParser(strict=True)
 
@@ -226,4 +245,18 @@ class TestCase(django.test.TestCase):
     def __str__(self):
         return u"%s (%s.%s)" % (self._testMethodName, strclass(self.__class__),self._testMethodName)
 
-        
+
+    def setUp(self):
+        # Replace settings paths with temporary directories.
+        super().setUp()
+        self._ietf_temp_dirs = {}  # trashed during tearDown, DO NOT put paths you care about in this
+        for setting in self.settings_temp_path_overrides:
+            self._ietf_temp_dirs[setting] = self.tempdir(slugify(setting))
+        self._ietf_saved_context = django.test.utils.override_settings(**self._ietf_temp_dirs)
+        self._ietf_saved_context.enable()
+
+    def tearDown(self):
+        self._ietf_saved_context.disable()
+        for dir in self._ietf_temp_dirs.values():
+            shutil.rmtree(dir)
+        super().tearDown()

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -188,6 +188,7 @@ class TemplateChecksTestCase(TestCase):
     templates = {}                      # type: Dict[str, Template]
 
     def setUp(self):
+        super().setUp()
         set_coverage_checking(False)
         self.paths = list(get_template_paths())
         self.paths.sort()
@@ -199,7 +200,7 @@ class TemplateChecksTestCase(TestCase):
 
     def tearDown(self):
         set_coverage_checking(True)
-        pass
+        super().tearDown()
 
     def test_parse_templates(self):
         errors = []
@@ -294,6 +295,7 @@ class TemplateChecksTestCase(TestCase):
 class TestWikiGlueManagementCommand(TestCase):
 
     def setUp(self):
+        super().setUp()
         # We create temporary wiki and svn directories, and provide them to the management
         # command through command line switches.  We have to do it this way because the
         # management command reads in its own copy of settings.py in its own python
@@ -310,6 +312,7 @@ class TestWikiGlueManagementCommand(TestCase):
         shutil.rmtree(os.path.dirname(self.wiki_dir_pattern))
         shutil.rmtree(os.path.dirname(self.svn_dir_pattern))
         set_coverage_checking(True)
+        super().tearDown()
 
     def test_wiki_create_output(self):
         for group_type in ['wg','rg','ag','area','rag']:
@@ -423,6 +426,7 @@ class TestBowerStaticFiles(TestCase):
 class DraftTests(TestCase):
 
     def setUp(self):
+        super().setUp()
         file,_ = submission_file(name='draft-test-draft-class',rev='00',format='txt',templatename='test_submission.txt',group=None)
         self.draft = Draft(text=file.getvalue(),source='draft-test-draft-class-00.txt',name_from_source=False)
 


### PR DESCRIPTION
This addresses [ticket 3414](https://trac.ietf.org/trac/ietfdb/ticket/3414). It modifies the base class for most datatracker test cases (`ietf.utils.test_utils.TestCase`) to automatically replace a number of paths in the settings with temporary directories. Subclasses can modify the list as needed, which is used to reduce repeated code in `setUp()` and `tearDown()` methods. The temporary directories are created and destroyed for each test, avoiding the possibility of cross-talk between test cases.

The first commit (389245c) is the change to `TestCase`. The second commit (f77291b) is updates to test classes that made use of `setUp()` and `tearDown()`. These were modified to call superclass methods and eliminated if they did not do anything other than what is now provided by the superclass. 

Additionally, in a number of places I replaced old-fashioned path and directory library calls with the `pathlib.Path` class. 