### PR TITLE
Include requester's last name in BoF request document name

### DIFF
--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -424,10 +424,13 @@ class BofreqResponsibleDocEventFactory(DocEventFactory):
 class BofreqFactory(BaseDocumentFactory):
     type_id = 'bofreq'
     title = factory.Faker('sentence')
-    name = factory.LazyAttribute(lambda o: 'bofreq-%s'%(xslugify(o.title)))
+    name = factory.LazyAttribute(lambda o: 'bofreq-%s-%s'%(xslugify(o.requester_lastname), xslugify(o.title)))
 
     bofreqeditordocevent = factory.RelatedFactory('ietf.doc.factories.BofreqEditorDocEventFactory','doc')
     bofreqresponsibledocevent = factory.RelatedFactory('ietf.doc.factories.BofreqResponsibleDocEventFactory','doc')
+
+    class Params:
+        requester_lastname = factory.Faker('last_name')
 
     @factory.post_generation
     def states(obj, create, extracted, **kwargs):

--- a/ietf/templates/doc/bofreq/new_bofreq.html
+++ b/ietf/templates/doc/bofreq/new_bofreq.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {# Copyright The IETF Trust 2021, All Rights Reserved #}
-{% load origin bootstrap3 static %}
+{% load origin bootstrap3 static textfilters %}
 
 {% block title %}Start a new BOF Request{% endblock %}
 
@@ -9,7 +9,7 @@
   <h1>Start a new BOF Request</h1>
 
 <p>Choose a short descriptive title for your request. Take time to choose a good initial title - it will be used to make the filename for your request's content. The title can be changed later, but the filename will not change.</p>
-<p>For example, a request with a title of "A new important bit" will be saved as "bofreq-a-new-important-bit-00.md".</p> 
+<p>For example, a request with a title of "A new important bit" will be saved as "bofreq-{{ user.person.last_name|xslugify|slice:"64" }}-a-new-important-bit-00.md".</p>
   <form class="upload-content form-horizontal" method="post" enctype="multipart/form-data">
     {% csrf_token %}
 


### PR DESCRIPTION
  * Make person requesting BoF available to the NewBofreqForm
  * Include a sanitized version of requester last name in the doc name
  * Update template to show accurate example name in the help text
  * Update test and factory to match the new name format

This addresses [ticket 3377](https://trac.ietf.org/trac/ietfdb/ticket/3377)