### PR TITLE
Properly update role_sets when editing nomcom members

### DIFF
--- a/ietf/nomcom/forms.py
+++ b/ietf/nomcom/forms.py
@@ -86,9 +86,23 @@ class MultiplePositionNomineeField(forms.MultipleChoiceField, PositionNomineeFie
         return result
 
 
-class NewEditMembersForm(forms.Form):
+class EditMembersForm(forms.Form):
+    members = SearchableEmailsField(only_users=True, all_emails=True, required=False)
+    liaisons = SearchableEmailsField(only_users=True, all_emails=True, required=False)
 
-    members = SearchableEmailsField(only_users=True,all_emails=True)
+    def __init__(self, nomcom, *args, **kwargs):
+        initial = kwargs.setdefault('initial', {})
+        roles = nomcom.group.role_set.filter(
+            name__slug__in=('member', 'liaison')
+        ).order_by('email__person__name').select_related('email')
+        initial['members'] = [
+            r.email for r in roles if r.name.slug == 'member'
+        ]
+        initial['liaisons'] = [
+                r.email for r in roles if r.name.slug =='liaison'
+        ]
+        super().__init__(*args, **kwargs)
+
 
 class EditNomcomForm(forms.ModelForm):
 


### PR DESCRIPTION
This addresses [ticket 3376](https://trac.ietf.org/trac/ietfdb/ticket/3376).

The `edit_members` view had a bug and two missing features: 
 1. (bug) editing the membership of a nomcom group would delete *all* roles for a given person in the nomcom group, not just the `member` role. If a person was also a `liaison`, they would be removed.
 2. (missing feature) `GroupEvent` entries were not created when the roles were modified
 3. (missing feature) `liaison` roles could not be edited through this interface
This patch fixes the bug and adds both features. Code is shared to the extent practical between the `Group` `edit` view and the `Nomcom` `edit_members` view.