### PR TITLE
Override application/octet-stream MIME type for markdown files

### DIFF
--- a/ietf/meeting/forms.py
+++ b/ietf/meeting/forms.py
@@ -6,6 +6,9 @@ import io
 import os
 import datetime
 import json
+import re
+
+from pathlib import Path
 
 from django import forms
 from django.conf import settings
@@ -326,14 +329,19 @@ class InterimCancelForm(forms.Form):
         self.fields['date'].widget.attrs['disabled'] = True
 
 class FileUploadForm(forms.Form):
+    """Base class for FileUploadForms
+
+    Abstract base class - subclasses must fill in the doc_type value with
+    the type of document they handle.
+    """
     file = forms.FileField(label='File to upload')
 
+    doc_type = None  # subclasses must set this
+
     def __init__(self, *args, **kwargs):
-        doc_type = kwargs.pop('doc_type')
-        assert doc_type in settings.MEETING_VALID_UPLOAD_EXTENSIONS
-        self.doc_type = doc_type
-        self.extensions = settings.MEETING_VALID_UPLOAD_EXTENSIONS[doc_type]
-        self.mime_types = settings.MEETING_VALID_UPLOAD_MIME_TYPES[doc_type]
+        assert self.doc_type in settings.MEETING_VALID_UPLOAD_EXTENSIONS
+        self.extensions = settings.MEETING_VALID_UPLOAD_EXTENSIONS[self.doc_type]
+        self.mime_types = settings.MEETING_VALID_UPLOAD_MIME_TYPES[self.doc_type]
         super(FileUploadForm, self).__init__(*args, **kwargs)
         label = '%s file to upload.  ' % (self.doc_type.capitalize(), )
         if self.doc_type == "slides":
@@ -346,6 +354,14 @@ class FileUploadForm(forms.Form):
         file = self.cleaned_data['file']
         validate_file_size(file)
         ext = validate_file_extension(file, self.extensions)
+
+        # override the Content-Type if needed
+        content_type_map = settings.MEETING_APPLICATION_OCTET_STREAM_OVERRIDES
+        filename = Path(file.name)
+        if file.content_type in 'application/octet-stream' and filename.suffix in content_type_map:
+            file.content_type = content_type_map[filename.suffix]
+            self.cleaned_data['file'] = file
+
         mime_type, encoding = validate_mime_type(file, self.mime_types)
         if not hasattr(self, 'file_encoding'):
             self.file_encoding = {}
@@ -361,6 +377,59 @@ class FileUploadForm(forms.Form):
             # as the sanitized version will most likely be useless.
             validate_no_html_frame(file)
         return file
+
+
+class UploadBlueSheetForm(FileUploadForm):
+    doc_type = 'bluesheets'
+
+
+class ApplyToAllFileUploadForm(FileUploadForm):
+    """FileUploadField that adds an apply_to_all checkbox
+
+    Checkbox can be disabled by passing show_apply_to_all_checkbox=False to the constructor.
+    This entirely removes the field from the form.
+    """
+    # Note: subclasses must set doc_type for FileUploadForm
+    apply_to_all = forms.BooleanField(label='Apply to all group sessions at this meeting',initial=True,required=False)
+
+    def __init__(self, show_apply_to_all_checkbox, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not show_apply_to_all_checkbox:
+            self.fields.pop('apply_to_all')
+        else:
+            self.order_fields(
+                sorted(
+                    self.fields.keys(),
+                    key=lambda f: 'zzzzzz' if f == 'apply_to_all' else f
+                )
+            )
+
+class UploadMinutesForm(FileUploadForm):
+    doc_type = 'minutes'
+
+
+class UploadAgendaForm(ApplyToAllFileUploadForm):
+    doc_type = 'agenda'
+
+
+class UploadSlidesForm(ApplyToAllFileUploadForm):
+    doc_type = 'slides'
+    title = forms.CharField(max_length=255)
+
+    def __init__(self, session, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = session
+
+    def clean_title(self):
+        title = self.cleaned_data['title']
+        # The current tables only handles Unicode BMP:
+        if ord(max(title)) > 0xffff:
+            raise forms.ValidationError("The title contains characters outside the Unicode BMP, which is not currently supported")
+        if self.session.meeting.type_id=='interim':
+            if re.search(r'-\d{2}$', title):
+                raise forms.ValidationError("Interim slides currently may not have a title that ends with something that looks like a revision number (-nn)")
+        return title
+
 
 class RequestMinutesForm(forms.Form):
     to = MultiEmailField()

--- a/ietf/meeting/tests_forms.py
+++ b/ietf/meeting/tests_forms.py
@@ -2,11 +2,19 @@
 # -*- coding: utf-8 -*-
 """Tests of forms in the Meeting application"""
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 
 from ietf.meeting.forms import FileUploadForm, ApplyToAllFileUploadForm
 from ietf.utils.test_utils import TestCase
 
 
+@override_settings(
+    MEETING_APPLICATION_OCTET_STREAM_OVERRIDES={'.md': 'text/markdown'},  # test relies on .txt not mapping
+    MEETING_VALID_UPLOAD_EXTENSIONS={'minutes': ['.txt', '.md']},  # test relies on .exe being absent
+    MEETING_VALID_UPLOAD_MIME_TYPES={'minutes': ['text/plain', 'text/markdown']},
+    MEETING_VALID_MIME_TYPE_EXTENSIONS={'text/plain': ['.txt'], 'text/markdown': ['.md']},
+    MEETING_VALID_UPLOAD_MIME_FOR_OBSERVED_MIME={'text/plain': ['text/plain', 'text/markdown']},
+)
 class FileUploadFormTests(TestCase):
     class TestClass(FileUploadForm):
         doc_type = 'minutes'

--- a/ietf/meeting/tests_forms.py
+++ b/ietf/meeting/tests_forms.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 """Tests of forms in the Meeting application"""
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.conf import settings
 
 from ietf.meeting.forms import FileUploadForm, ApplyToAllFileUploadForm
 from ietf.utils.test_utils import TestCase
@@ -85,10 +84,13 @@ class FileUploadFormTests(TestCase):
 
 
 class ApplyToAllFileUploadFormTests(TestCase):
+    class TestClass(ApplyToAllFileUploadForm):
+        doc_type = 'minutes'
+
     def test_has_apply_to_all_field_by_default(self):
-        form = ApplyToAllFileUploadForm(show_apply_to_all_checkbox=True)
+        form = ApplyToAllFileUploadFormTests.TestClass(show_apply_to_all_checkbox=True)
         self.assertIn('apply_to_all', form.fields)
 
     def test_no_show_apply_to_all_field(self):
-        form = ApplyToAllFileUploadForm(show_apply_to_all_checkbox=False)
+        form = ApplyToAllFileUploadFormTests.TestClass(show_apply_to_all_checkbox=False)
         self.assertNotIn('apply_to_all', form.fields)

--- a/ietf/meeting/tests_forms.py
+++ b/ietf/meeting/tests_forms.py
@@ -1,0 +1,94 @@
+# Copyright The IETF Trust 2021, All Rights Reserved
+# -*- coding: utf-8 -*-
+"""Tests of forms in the Meeting application"""
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.conf import settings
+
+from ietf.meeting.forms import FileUploadForm, ApplyToAllFileUploadForm
+from ietf.utils.test_utils import TestCase
+
+
+class FileUploadFormTests(TestCase):
+    class TestClass(FileUploadForm):
+        doc_type = 'minutes'
+
+    def test_accepts_valid_data(self):
+        test_file = SimpleUploadedFile(
+            name='file.txt',
+            content=b'plain text',
+            content_type='text/plain',
+        )
+
+        form = FileUploadFormTests.TestClass(files={'file': test_file})
+        self.assertTrue(form.is_valid(), 'Test data are valid input')
+        cleaned_file = form.cleaned_data['file']
+        self.assertEqual(cleaned_file.name, 'file.txt', 'Uploaded filename should not be changed')
+        with cleaned_file.open('rb') as f:
+            self.assertEqual(f.read(), b'plain text', 'Uploaded file contents should not be changed')
+        self.assertEqual(cleaned_file.content_type, 'text/plain', 'Content-Type should be overridden')
+
+    def test_overrides_content_type_application_octet_stream(self):
+        test_file = SimpleUploadedFile(
+            name='file.md',
+            content=b'plain text',
+            content_type='application/octet-stream',
+        )
+
+        form = FileUploadFormTests.TestClass(files={'file': test_file})
+        self.assertTrue(form.is_valid(), 'Test data are valid input')
+        cleaned_file = form.cleaned_data['file']
+        # Test that the test_file is what actually came out of the cleaning process.
+        # This is not technically required here, but the other tests check that test_file's
+        # content_type has not been changed. If cleaning does not modify the content_type
+        # when it succeeds, then those other tests are not actually testing anything.
+        self.assertEqual(cleaned_file, test_file, 'Cleaning should return the file object that was passed in')
+        self.assertEqual(cleaned_file.name, 'file.md', 'Uploaded filename should not be changed')
+        with cleaned_file.open('rb') as f:
+            self.assertEqual(f.read(), b'plain text', 'Uploaded file contents should not be changed')
+        self.assertEqual(cleaned_file.content_type, 'text/markdown', 'Content-Type should be overridden')
+
+    def test_overrides_only_application_octet_stream(self):
+        test_file = SimpleUploadedFile(
+            name='file.md',
+            content=b'plain text',
+            content_type='application/json'
+        )
+
+        form = FileUploadFormTests.TestClass(files={'file': test_file})
+        self.assertFalse(form.is_valid(), 'Test data are invalid input')
+        self.assertEqual(test_file.name, 'file.md', 'Uploaded filename should not be changed')
+        self.assertEqual(test_file.content_type, 'application/json', 'Uploaded Content-Type should not be changed')
+
+    def test_overrides_only_requested_extensions_when_valid_ext(self):
+        test_file = SimpleUploadedFile(
+            name='file.txt',
+            content=b'plain text',
+            content_type='application/octet-stream',
+        )
+
+        form = FileUploadFormTests.TestClass(files={'file': test_file})
+        self.assertFalse(form.is_valid(), 'Test data are invalid input')
+        self.assertEqual(test_file.name, 'file.txt', 'Uploaded filename should not be changed')
+        self.assertEqual(test_file.content_type, 'application/octet-stream', 'Uploaded Content-Type should not be changed')
+
+    def test_overrides_only_requested_extensions_when_invalid_ext(self):
+        test_file = SimpleUploadedFile(
+            name='file.exe',
+            content=b'plain text',
+            content_type='application/octet-stream'
+        )
+
+        form = FileUploadFormTests.TestClass(files={'file': test_file})
+        self.assertFalse(form.is_valid(), 'Test data are invalid input')
+        self.assertEqual(test_file.name, 'file.exe', 'Uploaded filename should not be changed')
+        self.assertEqual(test_file.content_type, 'application/octet-stream', 'Uploaded Content-Type should not be changed')
+
+
+class ApplyToAllFileUploadFormTests(TestCase):
+    def test_has_apply_to_all_field_by_default(self):
+        form = ApplyToAllFileUploadForm(show_apply_to_all_checkbox=True)
+        self.assertIn('apply_to_all', form.fields)
+
+    def test_no_show_apply_to_all_field(self):
+        form = ApplyToAllFileUploadForm(show_apply_to_all_checkbox=False)
+        self.assertNotIn('apply_to_all', form.fields)

--- a/ietf/meeting/views_proceedings.py
+++ b/ietf/meeting/views_proceedings.py
@@ -18,6 +18,8 @@ from ietf.secr.proceedings.utils import handle_upload_file
 from ietf.utils.text import xslugify
 
 class UploadProceedingsMaterialForm(FileUploadForm):
+    doc_type = 'procmaterials'
+
     use_url = forms.BooleanField(
         required=False,
         label='Use an external URL instead of uploading a document',
@@ -34,7 +36,7 @@ class UploadProceedingsMaterialForm(FileUploadForm):
         )
 
     def __init__(self, *args, **kwargs):
-        super().__init__(doc_type='procmaterials', *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields['file'].label = 'Select a file to upload. Allowed format{}: {}'.format(
             '' if len(self.mime_types) == 1 else 's',
             ', '.join(self.mime_types),

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -949,6 +949,12 @@ MEETING_VALID_MIME_TYPE_EXTENSIONS = {
     'application/pdf': ['.pdf'],
 }
 
+# Files uploaded with Content-Type application/octet-stream and an extension in this map will
+# be treated as if they had been uploaded with the mapped Content-Type value.
+MEETING_APPLICATION_OCTET_STREAM_OVERRIDES = {
+    '.md': 'text/markdown',
+}
+
 MEETING_VALID_UPLOAD_MIME_FOR_OBSERVED_MIME = {
     'text/plain':   ['text/plain', 'text/markdown', 'text/x-markdown', ],
     'text/html':    ['text/html', ],


### PR DESCRIPTION
This addresses [ticket 3163](https://trac.ietf.org/trac/ietfdb/ticket/3163)

Some browser/operating systems do not recognize files ending with `.md` as markdown files. When uploading meeting materials (minutes, agenda, etc), these browsers set the `Content-Type` to `application/octet-stream` instead of `text/markdown`. This work causes the `FileUploadForm` to change the `Content-Type` of files with extension `.md` to `text/markdown` if it was uploaded as `application/octet-stream`. There are further existing validation steps that heuristically verify that the received data is of a valid format.

The mapping from extension to overridden `Content-Type` is configured using a setting in `settings.py`. It seems likely that other formats may encounter similar problems, so this will hopefully avoid needing to modify the code just to accept a new extension.

In addition, I've refactored the various upload forms to better share code and reduce boilerplate. This is just for cleanup.