### PR TITLE
Avoid exceptions when an incoming email contains invalid unicode data

### DIFF
--- a/ietf/ipr/mail.py
+++ b/ietf/ipr/mail.py
@@ -11,7 +11,7 @@ import pytz
 import re
 
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text, force_str
+from django.utils.encoding import force_text, force_bytes
 
 import debug                            # pyflakes:ignore
 
@@ -174,7 +174,7 @@ def process_response_email(msg):
     a matching value in the reply_to field, associated to an IPR disclosure through
     IprEvent.  Create a Message object for the incoming message and associate it to
     the original message via new IprEvent"""
-    message = email.message_from_string(force_str(msg))
+    message = email.message_from_bytes(force_bytes(msg))
     to = message.get('To', '')
 
     # exit if this isn't a response we're interested in (with plus addressing)

--- a/ietf/ipr/management/commands/process_email.py
+++ b/ietf/ipr/management/commands/process_email.py
@@ -25,10 +25,8 @@ class Command(EmailOnFailureCommand):
         email = options.get('email', None)
         binary_input = io.open(email, 'rb') if email else sys.stdin.buffer
         self.msg_bytes = binary_input.read()
-        msg = self.msg_bytes.decode()
-
         try:
-            process_response_email(msg)
+            process_response_email(self.msg_bytes)
         except ValueError as e:
             raise CommandError(e)
 


### PR DESCRIPTION
This addresses [ticket 3489](https://trac.ietf.org/trac/ietfdb/ticket/3489).

Instead of decoding an incoming email and passing a string to the `process_response_email()` method, pass data as raw bytes. In the handler, use the bytes parser to convert the incoming data to a Message. This does two things: it allows access to the header data and replaces any invalid characters with valid Unicode chars to flag the substitution. All incoming email with invalid encoding so far has been spam, so will be dropped by the filters for valid header data already in the processing. Email that does pass the header inspection will be accepted with the substituted characters, but this is not thought likely to be encountered.

Tests are updated to reflect the method signature change and to test that invalid data are handled properly.