### PR TITLE
Allow group description to be edited for non-chartered groups

### DIFF
--- a/ietf/group/forms.py
+++ b/ietf/group/forms.py
@@ -66,6 +66,7 @@ class GroupForm(forms.Form):
     list_email = forms.CharField(max_length=64, required=False)
     list_subscribe = forms.CharField(max_length=255, required=False)
     list_archive = forms.CharField(max_length=255, required=False)
+    description = forms.CharField(widget=forms.Textarea, required=False, help_text='Text that appears on the "about" page.')
     urls = forms.CharField(widget=forms.Textarea, label="Additional URLs", help_text="Format: https://site/path (Optional description). Separate multiple entries with newline. Prefer HTTPS URLs where possible.", required=False)
     resources = forms.CharField(widget=forms.Textarea, label="Additional Resources", help_text="Format: tag value (Optional description). Separate multiple entries with newline. Prefer HTTPS URLs where possible.", required=False)
     closing_note = forms.CharField(widget=forms.Textarea, label="Closing note", required=False)
@@ -102,6 +103,9 @@ class GroupForm(forms.Form):
             field = None
 
         super(self.__class__, self).__init__(*args, **kwargs)
+
+        if not group_features or group_features.has_chartering_process:
+            self.fields.pop('description')  # do not show the description field for chartered groups
 
         for role_slug in self.used_roles:
             role_name = RoleName.objects.get(slug=role_slug)

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -885,7 +885,7 @@ def edit(request, group_type=None, acronym=None, action="edit", field=None):
         return fs.join(res)
 
     def diff(attr, name):
-        if field and attr != field:
+        if attr not in clean or (field and attr != field):
             return
         v = getattr(group, attr)
         if clean[attr] != v:
@@ -952,6 +952,7 @@ def edit(request, group_type=None, acronym=None, action="edit", field=None):
             diff('name', "Name")
             diff('acronym', "Acronym")
             diff('state', "State")
+            diff('description', "Description")
             diff('parent', "IETF Area" if group.type=="wg" else "Group parent")
             diff('list_email', "Mailing list email")
             diff('list_subscribe', "Mailing list subscribe address")
@@ -1068,6 +1069,7 @@ def edit(request, group_type=None, acronym=None, action="edit", field=None):
             init = dict(name=group.name,
                         acronym=group.acronym,
                         state=group.state,
+                        description = group.description,
                         parent=group.parent.id if group.parent else None,
                         list_email=group.list_email if group.list_email else None,
                         list_subscribe=group.list_subscribe if group.list_subscribe else None,

--- a/ietf/templates/group/group_about.html
+++ b/ietf/templates/group/group_about.html
@@ -246,7 +246,12 @@
     {# the linebreaks filter adds <p/>, no surrounding <p/> necessary: #}
     {{ group.charter_text|linebreaks }}
   {% else %}
-    <h2>About</h2>
+    <h2>
+      About
+      {% if can_edit_group %}
+        <a class="btn btn-default btn-xs" href="{% url 'ietf.group.views.edit' acronym=group.acronym field='description' %}">Edit</a>&nbsp;
+      {% endif %}
+    </h2>
     {% comment %}{{ group.description|default:"No description yet."|linebreaks }}{% endcomment %}
     {{ group.description|default:"No description yet."| apply_markup:"restructuredtext" }}
   {% endif %}


### PR DESCRIPTION
Addresses [ticket 3388](https://trac.ietf.org/trac/ietfdb/ticket/3388)

This allows the "About" text for non-chartered groups to be edited by users authorized to otherwise edit the group. Chartered groups have a separate process for approving the equivalent text, so they are excluded from such edits.