### PR TITLE
When navigating to signin from logout, set next page to /

### DIFF
--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -390,8 +390,15 @@ def startswith(x, y):
     return str(x).startswith(y)
 
 
-@register.filter(name='removesuffix', is_safe=True)
+@register.filter(name='removesuffix', is_safe=False)
 def removesuffix(value, suffix):
+    """Remove an exact-match suffix
+    
+    The is_safe flag is False because indiscriminate use of this could result in non-safe output.
+    See https://docs.djangoproject.com/en/2.2/howto/custom-template-tags/#filters-and-auto-escaping
+    which describes the possibility that removing characters from an escaped string may introduce
+    HTML-unsafe output.
+    """
     base = str(value)
     if base.endswith(suffix):
         return base[:-len(suffix)]

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -389,6 +389,16 @@ def expires_soon(x,request):
 def startswith(x, y):
     return str(x).startswith(y)
 
+
+@register.filter(name='removesuffix', is_safe=True)
+def removesuffix(value, suffix):
+    base = str(value)
+    if base.endswith(suffix):
+        return base[:-len(suffix)]
+    else:
+        return base
+
+
 @register.filter
 def has_role(user, role_names):
     from ietf.ietfauth.utils import has_role

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -94,6 +94,7 @@ class IetfAuthTests(TestCase):
         # try logging out
         r = self.client.get(urlreverse('django.contrib.auth.views.logout'))
         self.assertEqual(r.status_code, 200)
+        self.assertNotContains(r, "accounts/logout")
 
         r = self.client.get(urlreverse(ietf.ietfauth.views.profile))
         self.assertEqual(r.status_code, 302)

--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -72,7 +72,7 @@
             </ul>
         {% if not user.is_authenticated %}
             <p class="navbar-text"></p>
-            <a class="btn {% if server_mode and server_mode == "production" %}btn-warning{% else %}btn-default{% endif %} btn-sm navbar-btn" rel="nofollow" href="/accounts/login/?next={{request.get_full_path|urlencode}}">Sign in</a>
+            <a class="btn {% if server_mode and server_mode == "production" %}btn-warning{% else %}btn-default{% endif %} btn-sm navbar-btn" rel="nofollow" href="/accounts/login/?next={{request.get_full_path|removesuffix:"accounts/logout/"|urlencode}}">Sign in</a>
         {% endif %}
 
 	    <form class="navbar-form navbar-right hidden-xs" action="/doc/search/">


### PR DESCRIPTION
When a user logs in, the navigation flow of the authentication logic redirects the user back to the page from which the user clicked the "Sign In" button.  This is flawed when the user logs in from the logout page, because it logs them back out again.

This change will filter the logout page path - "accounts/logout" - out of the "next" parameter for the login page, so that the user will instead be redirected to the site root.

Fixes Trac3478.