### PR TITLE
Do not render template paths when in production mode

### DIFF
--- a/ietf/utils/templatetags/origin.py
+++ b/ietf/utils/templatetags/origin.py
@@ -1,27 +1,40 @@
+# Copyright The IETF Trust 2015-2022, All Rights Reserved
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
 from django import template
+from django.conf import settings
+
 import debug                            # pyflakes:ignore
+from ietf.utils import log
 
 register = template.Library()
 
 
 class OriginNode(template.Node):
-    def __init__(self, origin=None):
+    def __init__(self, origin_=None):
         # template file path if the template comes from a file:
-        self.origin = origin
+        self.origin = origin_
+
+    def relative_path(self):
+        origin_path = Path(str(self.origin))
+        try:
+            return origin_path.relative_to(settings.BASE_DIR)
+        except ValueError:
+            log.log(f'Rendering a template from outside the project root: {self.origin}')
+            return '** path outside project root **'
 
     def render(self, context):
-        if self.origin:
-            return "<!-- template: %s -->" % self.origin
+        if self.origin and settings.SERVER_MODE != 'production':
+            return f'<!-- template: {self.relative_path()} -->'
         else:
             return ""
 
 @register.tag
 def origin(parser, token):
-    """
-    Returns a node which renders the 
-    """
+    """Create a node indicating the path to the current template"""
     if hasattr(token, "source"):
         origin, source = token.source
-        return OriginNode(origin=origin)
+        return OriginNode(origin_=origin)
     else:
         return OriginNode()

--- a/ietf/utils/templatetags/tests.py
+++ b/ietf/utils/templatetags/tests.py
@@ -1,0 +1,41 @@
+# Copyright The IETF Trust 2022, All Rights Reserved
+# -*- coding: utf-8 -*-
+from django.template import Context, Origin, Template
+from django.test import override_settings
+
+from ietf.utils.test_utils import TestCase
+import debug  # pyflakes: ignore
+
+
+@override_settings(BASE_DIR='/fake/base/')
+class OriginTests(TestCase):
+    def test_origin_not_shown_in_production(self):
+        template = Template(
+            '{% load origin %}{% origin %}',
+            origin=Origin('/fake/base/templates/my-template.html'),
+        )
+        with override_settings(SERVER_MODE='production'):
+            self.assertEqual(template.render(Context()), '')
+
+    def test_origin_shown_in_development_and_test(self):
+        template = Template(
+            '{% load origin %}{% origin %}',
+            origin=Origin('/fake/base/templates/my-template.html'),
+        )
+        for mode in ['development', 'test']:
+            with override_settings(SERVER_MODE=mode):
+                output = template.render(Context())
+                self.assertIn('templates/my-template.html', output)
+                for component in ['fake', 'base']:
+                    self.assertNotIn(component, output, 'Reported path should be relative to BASE_DIR')
+
+    def test_origin_outside_base_dir(self):
+        template = Template(
+            '{% load origin %}{% origin %}',
+            origin=Origin('/different/templates/my-template.html'),
+        )
+        with override_settings(SERVER_MODE='development'):
+            for component in ['fake', 'base', 'different', 'templates']:
+                output = template.render(Context())
+                self.assertNotIn(component, output,
+                                 'Full path components should not be revealed in html')


### PR DESCRIPTION
A custom Django template tag causes `{% origin %}` to render the path of the current template. This is useful for debugging, but reveals details about the production filesystem layout. As a best practice, these should not be made public.

This disables output from the origin tag when in production mode. In other modes (i.e., development and test), it displays only the path relative to the Django project root directory. This is adequate information for debugging but prevents revealing absolute paths should the output be inadvertently re-enabled in production mode.