### PR TITLE
Create Meetecho conference when requesting an interim meeting

### DIFF
--- a/ietf/meeting/forms.py
+++ b/ietf/meeting/forms.py
@@ -258,7 +258,9 @@ class InterimSessionModelForm(forms.ModelForm):
         return duration
 
     def clean(self):
-        if not (self.cleaned_data['remote_participation'] == 'meetecho' or self.cleaned_data['remote_instructions']):
+        if not (self.cleaned_data.get('remote_participation', None) == 'meetecho'
+                or self.cleaned_data['remote_instructions']
+        ):
             self.add_error('remote_instructions', 'This field is required')
         return self.cleaned_data
 

--- a/ietf/meeting/forms.py
+++ b/ietf/meeting/forms.py
@@ -16,6 +16,7 @@ from django.core import validators
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.forms import BaseInlineFormSet
+from django.utils.functional import cached_property
 
 import debug                            # pyflakes:ignore
 
@@ -263,6 +264,14 @@ class InterimSessionModelForm(forms.ModelForm):
         ):
             self.add_error('remote_instructions', 'This field is required')
         return self.cleaned_data
+
+    # Override to ignore the non-model 'remote_participation' field when computing has_changed()
+    @cached_property
+    def changed_data(self):
+        data = super().changed_data
+        if 'remote_participation' in data:
+            data.remove('remote_participation')
+        return data
 
     def save(self, *args, **kwargs):
         """NOTE: as the baseform of an inlineformset self.save(commit=True)

--- a/ietf/meeting/management/commands/meetecho_conferences.py
+++ b/ietf/meeting/management/commands/meetecho_conferences.py
@@ -16,22 +16,22 @@ class Command(BaseCommand):
     
     def add_arguments(self, parser) -> None:
         parser.add_argument('group', type=str)
+        parser.add_argument('-d', '--delete', type=int, action='append',
+                            metavar='SESSION_PK',
+                            help='Delete the conference associated with the specified Session')
     
-    def handle(self, group, *args, **options):
+    def handle(self, group, delete, *args, **options):
         conf_mgr = ConferenceManager(settings.MEETECHO_API_CONFIG)
-        try:
-            confs = conf_mgr.fetch(group)
-        except MeetechoAPIError as err:
-            raise CommandError('API error fetching Meetecho conference data') from err
+        if delete:
+            self.handle_delete_conferences(conf_mgr, group, delete)
+        else:
+            self.handle_list_conferences(conf_mgr, group)
 
+    def handle_list_conferences(self, conf_mgr, group):
+        confs, conf_sessions = self.fetch_conferences(conf_mgr, group)
         self.stdout.write(f'Meetecho conferences for {group}:\n\n')
         for conf in confs:
-            sessions = Session.objects.filter(
-                group__acronym=group,
-                meeting__date__gte=datetime.date.today(),
-                remote_instructions__contains=conf.url,
-            )
-            sessions_desc = ', '.join(str(s.pk) for s in sessions) or None
+            sessions_desc = ', '.join(str(s.pk) for s in conf_sessions[conf.id]) or None
             self.stdout.write(
                 dedent(f'''\
                 * {conf.description}
@@ -42,3 +42,50 @@ class Command(BaseCommand):
                 
                 ''')
             )
+
+    def handle_delete_conferences(self, conf_mgr, group, session_pks_to_delete):
+        sessions_to_delete = Session.objects.filter(pk__in=session_pks_to_delete)
+        confs, conf_sessions = self.fetch_conferences(conf_mgr, group)
+        confs_to_delete = []
+        descriptions = []
+        for session in sessions_to_delete:
+            for conf in confs:
+                associated = conf_sessions[conf.id]
+                if session in associated:
+                    confs_to_delete.append(conf)
+                    sessions_desc = ', '.join(str(s.pk) for s in associated) or None
+                    descriptions.append(
+                        f'{conf.description} ({conf.start_time}, {int(conf.duration.total_seconds() // 60)} mins) - used by {sessions_desc}'
+                    )
+        if len(confs_to_delete) > 0:
+            self.stdout.write('Will delete:')
+            for desc in descriptions:
+                self.stdout.write(f'* {desc}')
+
+            try:
+                proceed = input('Proceed [y/N]? ').lower()
+            except EOFError:
+                proceed = 'n'
+            if proceed in ['y', 'yes']:
+                for conf, desc in zip(confs_to_delete, descriptions):
+                    conf.delete()
+                    self.stdout.write(f'Deleted {desc}')
+            else:
+                self.stdout.write('Nothing deleted.')
+        else:
+            self.stdout.write('No associated Meetecho conferences found')
+
+    def fetch_conferences(self, conf_mgr, group):
+        try:
+            confs = conf_mgr.fetch(group)
+        except MeetechoAPIError as err:
+            raise CommandError('API error fetching Meetecho conference data') from err
+
+        conf_sessions = {}
+        for conf in confs:
+            conf_sessions[conf.id] = Session.objects.filter(
+                group__acronym=group,
+                meeting__date__gte=datetime.date.today(),
+                remote_instructions__contains=conf.url,
+            )
+        return confs, conf_sessions

--- a/ietf/meeting/management/commands/meetecho_conferences.py
+++ b/ietf/meeting/management/commands/meetecho_conferences.py
@@ -1,0 +1,62 @@
+# Copyright The IETF Trust 2022, All Rights Reserved
+# -*- coding: utf-8 -*-
+import datetime
+
+from textwrap import dedent
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from ietf.meeting.models import Session
+from ietf.utils.meetecho import MeetechoAPI, MeetechoAPIError
+
+
+class Command(BaseCommand):
+    help = 'Manage Meetecho conferences'
+    
+    def add_arguments(self, parser) -> None:
+        parser.add_argument('group', type=str)
+    
+    def handle(self, group, *args, **options):
+        api = MeetechoAPI(
+            api_base=settings.MEETECHO_API_BASE,
+            client_id=settings.MEETECHO_CLIENT_ID,
+            client_secret=settings.MEETECHO_CLIENT_SECRET,
+        )
+        
+        try:
+            result = api.retrieve_wg_tokens(group)
+        except MeetechoAPIError as err:
+            raise CommandError('Unable to retrieve wg tokens') from err
+        try:
+            token = result['tokens'][group]
+        except KeyError as err:
+            raise CommandError('Unexpected data returned when retrieving wg tokens') from err
+        
+        try:
+            result = api.fetch_meetings(token)
+        except MeetechoAPIError as err:
+            raise CommandError('Unable to fetch meetings') from err
+        try:
+            all_room_data = result['rooms']
+        except KeyError as err:
+            raise CommandError('Unexpected data returned from when fetching meetings') from err
+    
+        self.stdout.write(f'Meetecho conferences for {group}:\n\n')
+        for uuid, data in all_room_data.items():
+            sessions = Session.objects.filter(
+                group__acronym=group,
+                meeting__date__gte=datetime.date.today(),
+                remote_instructions__contains=data['url'],
+            )
+            sessions_desc = ', '.join(str(s.pk) for s in sessions) or None
+            self.stdout.write(
+                dedent(f'''\
+                * {data['room']['description']}
+                    Start time: {data['room']['start_time']} 
+                    Duration: {int(data['room']['duration'].total_seconds() // 60)} minutes
+                    URL: {data['url']}
+                    Associated session PKs: {sessions_desc}
+                
+                ''')
+            )

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -49,6 +49,7 @@ from ietf.meeting.views import session_draft_list, parse_agenda_filter_params
 from ietf.name.models import SessionStatusName, ImportantDateName, RoleName, ProceedingsMaterialTypeName
 from ietf.utils.decorators import skip_coverage
 from ietf.utils.mail import outbox, empty_outbox, get_payload_text
+from ietf.utils.meetecho import Conference
 from ietf.utils.test_utils import TestCase, login_testing_unauthorized, unicontent
 from ietf.utils.text import xslugify
 
@@ -4640,6 +4641,129 @@ class InterimTests(TestCase):
 
         r = self.client.post(urlreverse("ietf.meeting.views.interim_request"),data)
         self.assertContains(r, 'days must be consecutive')
+
+    def do_interim_request_meetecho_test(self, mock_conf_mgr, meeting_type):
+        """Helper to run interim_request_meetecho tests for various meeting types"""
+        make_meeting_test_data()
+        date = datetime.date.today() + datetime.timedelta(days=30)
+        date2 = date + datetime.timedelta(days=1)
+        time = datetime.datetime.now().time().replace(microsecond=0, second=0)
+        dt = datetime.datetime.combine(date, time)
+        dt2 = datetime.datetime.combine(date2, time)
+        group = Group.objects.get(acronym='mars')
+        time_zone = 'America/Los_Angeles'
+        self.client.login(username="secretary", password="secretary+password")
+        data = {
+            'group': group.pk,
+            'meeting_type': meeting_type,
+            'time_zone': time_zone,
+            'session_set-0-date': date.strftime("%Y-%m-%d"),
+            'session_set-0-time': time.strftime('%H:%M'),
+            'session_set-0-requested_duration': '03:00:00',
+            'session_set-0-remote_instructions': '',
+            'session_set-INITIAL_FORMS':0,
+        }
+        if meeting_type == 'single':
+            data['session_set-TOTAL_FORMS'] = 1
+        else:
+            data.update({
+                'session_set-1-date': date2.strftime("%Y-%m-%d"),
+                'session_set-1-time': time.strftime('%H:%M'),
+                'session_set-1-requested_duration': '03:00:00',
+                'session_set-1-remote_instructions': '',
+                'session_set-TOTAL_FORMS':2,
+            })
+
+        # check that calling with no value for remote_properties or remote_instructions
+        # generates an error
+        r = self.client.post(urlreverse('ietf.meeting.views.interim_request'), data)
+        self.assertFormsetError(r, 'formset', 0, 'remote_instructions', 'This field is required')
+        if meeting_type != 'single':
+            self.assertFormsetError(r, 'formset', 1, 'remote_instructions', 'This field is required')
+
+        # check that calling with no value for remote_instructions and remote_properties
+        # set to 'manual' generates an error
+        data['session_set-0-remote_participation'] = 'manual'
+        if meeting_type != 'single':
+            data['session_set-1-remote_participation'] = 'manual'
+        r = self.client.post(urlreverse('ietf.meeting.views.interim_request'), data)
+        self.assertFormsetError(r, 'formset', 0, 'remote_instructions', 'This field is required')
+        if meeting_type != 'single':
+            self.assertFormsetError(r, 'formset', 1, 'remote_instructions', 'This field is required')
+
+        # now ask to automatically create a meetecho session and mock the necessary
+        # manager method to make it work
+        data['session_set-0-remote_participation'] = 'meetecho'
+        if meeting_type != 'single':
+            data['session_set-1-remote_participation'] = 'meetecho'
+        mock_create = mock_conf_mgr.return_value.create
+        mock_create.side_effect = [
+            [Conference(
+                mock_conf_mgr,
+                id=1,
+                public_id='this-is-a-uuid',
+                description='the-description',
+                start_time=dt,
+                duration=datetime.timedelta(hours=3),
+                url='https://example.com/faked-meetecho/this-is-a-uuid',
+                deletion_token='delete-me',
+            )],
+            [Conference(
+                mock_conf_mgr,
+                id=2,
+                public_id='this-is-another-uuid',
+                description='the-description',
+                start_time=dt2,
+                duration=datetime.timedelta(hours=3),
+                url='https://example.com/faked-meetecho/this-is-another-uuid',
+                deletion_token='delete-me-too',
+            )],
+        ]
+        # Get sessions directly - if the interims were created as a series, there will
+        # be a new meeting for each session so using meeting.session_set won't work.
+        sessions_before = list(Session.objects.values_list('pk', flat=True))
+        r = self.client.post(urlreverse('ietf.meeting.views.interim_request'), data)
+        self.assertRedirects(r,urlreverse('ietf.meeting.views.upcoming'))
+        sessions = Session.objects.exclude(pk__in=sessions_before)
+        self.assertEqual(sessions[0].remote_instructions,
+                         'https://example.com/faked-meetecho/this-is-a-uuid')
+        if meeting_type != 'single':
+            self.assertEqual(sessions[1].remote_instructions,
+                             'https://example.com/faked-meetecho/this-is-another-uuid')
+        expected = [
+            ({
+                 'group': group,
+                 'description': sessions[0].meeting.number,
+                 'start_time': dt,
+                 'duration': datetime.timedelta(hours=3),
+             },),
+        ]
+        if meeting_type != 'single':
+            expected.append((
+                {
+                    'group': group,
+                    'description': sessions[1].meeting.number,
+                    'start_time': dt2,
+                    'duration': datetime.timedelta(hours=3),
+                },
+            ))
+        self.assertCountEqual(mock_create.call_args_list, expected,
+            'Incorrect call to meetecho.ConferenceManager create() method')
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_meetecho_single(self, mock_conf_mgr):
+        """Create a Meetecho conference for a single-session interim request"""
+        self.do_interim_request_meetecho_test(mock_conf_mgr, 'single')
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_meetecho_multi_day(self, mock_conf_mgr):
+        """Create a Meetecho conference for a multi-day interim request"""
+        self.do_interim_request_meetecho_test(mock_conf_mgr, 'multi-day')
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_meetecho_series(self, mock_conf_mgr):
+        """Create a Meetecho conference for a series interim request"""
+        self.do_interim_request_meetecho_test(mock_conf_mgr, 'series')
 
     def test_interim_request_multi_day_cancel(self):
         """All sessions of a multi-day interim request should be canceled"""

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1236,6 +1236,13 @@ qvNU+qRWi+YXrITsgn92/gVxX5AoK0n+s5Lx7fpjxkARVi66SF6zTJnX
 # Default timeout for HTTP requests via the requests library
 DEFAULT_REQUESTS_TIMEOUT = 20  # seconds
 
+
+# Meetecho API setup
+MEETECHO_API_BASE = 'https://meetings.conf.meetecho.com/api/v1/'
+MEETECHO_CLIENT_ID = 'datatracker'
+MEETECHO_CLIENT_SECRET = 'some secret'
+
+
 # Put the production SECRET_KEY in settings_local.py, and also any other
 # sensitive or site-specific changes.  DO NOT commit settings_local.py to svn.
 from ietf.settings_local import *            # pyflakes:ignore pylint: disable=wildcard-import

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1238,9 +1238,11 @@ DEFAULT_REQUESTS_TIMEOUT = 20  # seconds
 
 
 # Meetecho API setup
-MEETECHO_API_BASE = 'https://meetings.conf.meetecho.com/api/v1/'
-MEETECHO_CLIENT_ID = 'datatracker'
-MEETECHO_CLIENT_SECRET = 'some secret'
+MEETECHO_API_CONFIG = {
+    'api_base': 'https://meetings.conf.meetecho.com/api/v1/',
+    'client_id': 'datatracker',
+    'client_secret': 'some secreat',
+}
 
 
 # Put the production SECRET_KEY in settings_local.py, and also any other

--- a/ietf/static/ietf/js/meeting-interim-request.js
+++ b/ietf/static/ietf/js/meeting-interim-request.js
@@ -26,6 +26,11 @@ var interimRequest = {
         $('input[name$="-time"]').each(interimRequest.calculateEndTime);
         $('input[name$="-time"]').each(interimRequest.updateInfo);
         $('#id_country').select2({placeholder:"Country"});
+        const remoteParticipations = $('select[id$="-remote_participation"]');
+        remoteParticipations.change(
+          evt => interimRequest.updateRemoteInstructionsVisibility(evt.target)
+        );
+        remoteParticipations.each((index, elt) => interimRequest.updateRemoteInstructionsVisibility(elt));
     },
 
     addSession : function() {
@@ -225,6 +230,22 @@ var interimRequest = {
             $(".location").prop('disabled', false);
         } else {
             $(".location").prop('disabled', true);
+        }
+    },
+
+    updateRemoteInstructionsVisibility : function(elt) {
+        const sessionSetPrefix = elt.id.replace('-remote_participation', '');
+        const remoteInstructionsId = sessionSetPrefix + '-remote_instructions';
+        const remoteInstructions = $('#' + remoteInstructionsId);
+
+        switch (elt.value) {
+            case 'meetecho':
+                remoteInstructions.closest('.form-group').hide();
+                break;
+
+            default:
+                remoteInstructions.closest('.form-group').show();
+                break;
         }
     }
 }

--- a/ietf/templates/meeting/interim_request.html
+++ b/ietf/templates/meeting/interim_request.html
@@ -121,13 +121,27 @@
         </div>
     </div>
 
+    <div class="form-group">
+        <label for="id_session_set-{{ forloop.counter0 }}-remote_participation" class="col-md-2 control-label">
+            Remote Participation
+        </label>
+        <div class="col-md-10">
+            <div class="row">
+                <div class="col-md-12">
+                    {% render_field form.remote_participation class="form-control" %}
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="form-group{% if form.remote_instructions.errors %} alert alert-danger{% endif %}">
-        <label for="id_session_set-{{ forloop.counter0 }}-remote_instructions" class="col-md-2 control-label required">Remote Instructions</label>
-        <div class="col-md-10">{% render_field form.remote_instructions class="form-control" placeholder="Webex (or other) URL or descriptive information (see below)" %}
+        <label for="id_session_set-{{ forloop.counter0 }}-remote_instructions" class="control-label col-md-2 required">Instructions</label>
+        <div class="col-md-10">
+            {% render_field form.remote_instructions class="form-control" placeholder="Webex (or other) URL or descriptive information (see below)" %}
             <p class="help-block">
-            For virtual interims, a conference link <b>should be provided in the original request</b> in all but the most unusual circumstances.
-            Otherwise, "Remote participation is not supported" or "Remote participation information will be obtained at the time of approval" are acceptable values.
-            See <a href="https://www.ietf.org/forms/wg-webex-account-request/">here</a> for more on remote participation support.
+                For virtual interims, a conference link <b>should be provided in the original request</b> in all but the most unusual circumstances.
+                Otherwise, "Remote participation is not supported" or "Remote participation information will be obtained at the time of approval" are acceptable values.
+                See <a href="https://www.ietf.org/forms/wg-webex-account-request/">here</a> for more on remote participation support.
             </p>
         </div>
         {% if form.remote_instructions.errors %}<span class="help-inline">{{ form.remote_instructions.errors }}</span>{% endif %}

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -1,0 +1,110 @@
+# Copyright The IETF Trust 2021, All Rights Reserved
+#
+"""Meetecho interim meeting scheduling API
+
+Implements the v1 API described in email from alex@meetecho.com
+on 2021-12-09.
+
+API methods return Python objects equivalent to the JSON structures
+specified in the API documentation. Times and durations are represented
+in the Python API by datetime and timedelta objects, respectively.
+"""
+import requests
+
+from datetime import datetime, timedelta
+from json import JSONDecodeError
+from typing import Sequence
+from urllib.parse import urljoin
+
+
+class MeetechoAPI:
+    def __init__(self, api_base: str, client_id: str, client_secret: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._session = requests.Session()
+        self.api_base = api_base
+
+    def _request(self, method, url, api_token=None, json=None):
+        """Execute an API request"""
+        headers = {}
+        if api_token is not None:
+            headers['Authorization'] = f'bearer {api_token}'
+
+        try:
+            response = self._session.request(
+                method,
+                urljoin(self.api_base, url),
+                headers=headers,
+                json=json,
+                timeout=3.01,  # python-requests doc recommend slightly > a multiple of 3 seconds
+            )
+        except requests.RequestException as err:
+            raise MeetechoAPIError(str(err)) from err
+        if response.status_code != 200:
+            raise MeetechoAPIError(f'API request failed (HTTP status code = {response.status_code})')
+
+        try:
+            return response.json()
+        except JSONDecodeError as err:
+            raise MeetechoAPIError('Error decoding response as JSON') from err
+
+    def _deserialize_time(self, s: str) -> datetime:
+        return datetime.strptime(s, '%Y-%m-%d %H:%M:%S')
+
+    def _serialize_time(self, dt: datetime) -> str:
+        return dt.strftime('%Y-%m-%d %H:%M:%S')
+
+    def _deserialize_duration(self, minutes: int) -> timedelta:
+        return timedelta(minutes=minutes)
+
+    def _serialize_duration(self, td: timedelta) -> int:
+        return int(td.total_seconds() // 60)
+
+    def _deserialize_meetings_response(self, response):
+        """In-place deserialization of response data structure
+
+        Deserializes data in the structure where needed (currently, that's time-related structures)
+        """
+        for session_data in response['rooms'].values():
+            session_data['room']['start_time'] = self._deserialize_time(session_data['room']['start_time'])
+            session_data['room']['duration'] = self._deserialize_duration(session_data['room']['duration'])
+        return response
+
+    def retrieve_wg_tokens(self, acronyms: Sequence[str]):
+        """Retrieve API tokens for one or more WGs"""
+        return self._request(
+            'POST', 'auth/ietfservice/tokens',
+            json={
+                'client': self.client_id,
+                'secret': self.client_secret,
+                'wgs': acronyms,
+            }
+        )
+
+    def schedule_meeting(self, wg_token: str, description: str, start_time: datetime, duration: timedelta,
+                         extrainfo=''):
+        """Schedule a meeting session"""
+        return self._deserialize_meetings_response(
+            self._request(
+                'POST', 'meeting/interim/createRoom',
+                api_token=wg_token,
+                json={
+                    'description': description,
+                    'start_time': self._serialize_time(start_time),
+                    'duration': self._serialize_duration(duration),
+                    'extrainfo': extrainfo,
+                },
+            )
+        )
+
+    def fetch_meetings(self, wg_token: str):
+        return self._deserialize_meetings_response(
+            self._request('GET', 'meeting/interim/fetchRooms', api_token=wg_token)
+        )
+
+    def delete_meeting(self, deletion_token: str):
+        return self._request('POST', 'meeting/interim/deleteRoom', api_token=deletion_token)
+
+
+class MeetechoAPIError(Exception):
+    """Base class for MeetechoAPI exceptions"""

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -210,6 +210,15 @@ class Conference:
         ]
         return f'Conference({", ".join(props)})'
 
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in [
+                'id', 'public_id', 'description', 'start_time',
+                'duration', 'url', 'deletion_token'
+            ]
+        )
+
     def delete(self):
         self._manager.delete_conference(self)
 

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -71,7 +71,11 @@ class MeetechoAPI:
         return response
 
     def retrieve_wg_tokens(self, acronyms: Sequence[str]):
-        """Retrieve API tokens for one or more WGs"""
+        """Retrieve API tokens for one or more WGs
+
+        :param acronyms: list of WG acronyms for which tokens are requested 
+        :return: {'tokens': {acronym0: token0, acronym1: token1, ...}}
+        """
         return self._request(
             'POST', 'auth/ietfservice/tokens',
             json={
@@ -83,7 +87,31 @@ class MeetechoAPI:
 
     def schedule_meeting(self, wg_token: str, description: str, start_time: datetime, duration: timedelta,
                          extrainfo=''):
-        """Schedule a meeting session"""
+        """Schedule a meeting session
+        
+        Return structure is:
+          {
+            "rooms": {
+              "<session UUID>": {
+                "room": {
+                  "id": int,
+                  "start_time": datetime,
+                  "duration": timedelta
+                  description: str,
+                },
+                "url": str,
+                "deletion_token": str
+              }
+            }
+          }
+              
+        :param wg_token: token retrieved via retrieve_wg_tokens() 
+        :param description: str describing the meeting
+        :param start_time: starting time as a datetime
+        :param duration: duration as a timedelta
+        :param extrainfo: str with additional information for Meetecho staff
+        :return: scheduled meeting data dict
+        """
         return self._deserialize_meetings_response(
             self._request(
                 'POST', 'meeting/interim/createRoom',
@@ -98,11 +126,37 @@ class MeetechoAPI:
         )
 
     def fetch_meetings(self, wg_token: str):
+        """Fetch all meetings scheduled for a given wg
+
+        Return structure is:
+          {
+            "rooms": {
+              "<session UUID>": {
+                "room": {
+                  "id": int,
+                  "start_time": datetime,
+                  "duration": timedelta
+                  description: str,
+                },
+                "url": str,
+                "deletion_token": str
+              }
+            }
+          }
+
+        :param wg_token: token from retrieve_wg_tokens()
+        :return: meeting data dict
+        """
         return self._deserialize_meetings_response(
             self._request('GET', 'meeting/interim/fetchRooms', api_token=wg_token)
         )
 
     def delete_meeting(self, deletion_token: str):
+        """Remove a scheduled meeting
+
+        :param deletion_token: deletion_key from fetch_meetings() or schedule_meeting() return data
+        :return: {}
+        """
         return self._request('POST', 'meeting/interim/deleteRoom', api_token=deletion_token)
 
 

--- a/ietf/utils/tests_meetecho.py
+++ b/ietf/utils/tests_meetecho.py
@@ -1,0 +1,254 @@
+# Copyright The IETF Trust 2021, All Rights Reserved
+# -*- coding: utf-8 -*-
+import datetime
+from urllib.parse import urljoin
+
+import requests
+import requests_mock
+from django.conf import settings
+
+from ietf.utils.tests import TestCase
+from .meetecho import MeetechoAPI, MeetechoAPIError
+
+API_BASE = 'https://meetecho-api.example.com'
+CLIENT_ID = 'datatracker'
+CLIENT_SECRET = 'very secret'
+
+
+class APITests(TestCase):
+    retrieve_token_url = urljoin(API_BASE, 'auth/ietfservice/tokens')
+    schedule_meeting_url = urljoin(API_BASE, 'meeting/interim/createRoom')
+    fetch_meetings_url = urljoin(API_BASE, 'meeting/interim/fetchRooms')
+    delete_meetings_url = urljoin(API_BASE, 'meeting/interim/deleteRoom')
+
+    def setUp(self):
+        super().setUp()
+        self._replace_settings(
+            MEETECHO_API_BASE=API_BASE,
+            MEETECHO_CLIENT_ID=CLIENT_ID,
+            MEETECHO_CLIENT_SECRET=CLIENT_SECRET,
+        )
+        self.requests_mock = requests_mock.Mocker()
+        self.requests_mock.start()
+
+    def tearDown(self):
+        self.requests_mock.stop()
+        self._restore_settings()
+        super().tearDown()
+
+    def _replace_settings(self, **new_settings):
+        if not hasattr(self, '_saved_settings'):
+            self._saved_settings = {}
+        for k, v in new_settings.items():
+            self._saved_settings[k] = getattr(settings, k, None)
+            setattr(settings, k, v)
+
+    def _restore_settings(self):
+        for k, v in getattr(self, '_saved_settings', {}).items():
+            if v is None:
+                delattr(settings, k)
+            else:
+                setattr(settings, k, v)
+
+    def test_retrieve_wg_tokens(self):
+        data_to_fetch = {
+            'tokens': {
+                'acro': 'wg-token-value-for-acro',
+                'beta': 'different-token',
+                'gamma': 'this-is-not-the-same',
+            }
+        }
+        self.requests_mock.post(self.retrieve_token_url, status_code=200, json=data_to_fetch)
+
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.retrieve_wg_tokens(['acro', 'beta', 'gamma'])
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertEqual(
+            request.headers['Content-Type'],
+            'application/json',
+            'Incorrect request content-type',
+        )
+        self.assertEqual(
+            request.json(),
+            {
+                'client': CLIENT_ID,
+                'secret': CLIENT_SECRET,
+                'wgs': ['acro', 'beta', 'gamma'],
+            }
+        )
+        self.assertEqual(api_response, data_to_fetch)
+
+    def test_schedule_meeting(self):
+        self.requests_mock.post(
+            self.schedule_meeting_url,
+            status_code=200,
+            json={
+                'rooms': {
+                    '3d55bce0-535e-4ba8-bb8e-734911cf3c32': {
+                        'room': {
+                            'id': 18,
+                            'start_time': '2021-09-14 10:00:00',
+                            'duration': 130,
+                            'description': 'interim-2021-wgname-01',
+                        },
+                        'url': 'https://meetings.conf.meetecho.com/interim/?short=3d55bce0-535e-4ba8-bb8e-734911cf3c32',
+                        'deletion_token': 'session-deletion-token',
+                    },
+                }
+            },
+        )
+
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.schedule_meeting(
+            wg_token='my-token',
+            start_time=datetime.datetime(2021, 9, 14, 10, 0, 0),
+            duration=datetime.timedelta(minutes=130),
+            description='interim-2021-wgname-01',
+            extrainfo='message for staff',
+        )
+
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertIn('Authorization', request.headers)
+        self.assertEqual(
+            request.headers['Content-Type'],
+            'application/json',
+            'Incorrect request content-type',
+        )
+        self.assertEqual(request.headers['Authorization'], 'bearer my-token',
+                         'Incorrect request authorization header')
+        self.assertEqual(
+            request.json(),
+            {
+                'duration': 130,
+                'start_time': '2021-09-14 10:00:00',
+                'extrainfo': 'message for staff',
+                'description': 'interim-2021-wgname-01',
+            },
+            'Incorrect request content'
+        )
+        self.assertEqual(
+            api_response,
+            {
+                'rooms': {
+                    '3d55bce0-535e-4ba8-bb8e-734911cf3c32': {
+                        'room': {
+                            'id': 18,
+                            'start_time': datetime.datetime(2021, 9, 14, 10, 0, 0),
+                            'duration': datetime.timedelta(minutes=130),
+                            'description': 'interim-2021-wgname-01',
+                        },
+                        'url': 'https://meetings.conf.meetecho.com/interim/?short=3d55bce0-535e-4ba8-bb8e-734911cf3c32',
+                        'deletion_token': 'session-deletion-token',
+                    },
+                }
+            },
+        )
+
+    def test_fetch_meetings(self):
+        self.maxDiff = 2048
+        self.requests_mock.get(
+            self.fetch_meetings_url,
+            status_code=200,
+            json={
+                'rooms': {
+                    '3d55bce0-535e-4ba8-bb8e-734911cf3c32': {
+                        'room': {
+                            'id': 18,
+                            'start_time': '2021-09-14 10:00:00',
+                            'duration': 130,
+                            'description': 'interim-2021-wgname-01',
+                        },
+                        'url': 'https://meetings.conf.meetecho.com/interim/?short=3d55bce0-535e-4ba8-bb8e-734911cf3c32',
+                        'deletion_token': 'session-deletion-token-01',
+                    },
+                    'e68e96d4-d38f-475b-9073-ecab46ca96a5': {
+                        'room': {
+                            'id': 23,
+                            'start_time': '2021-09-15 14:30:00',
+                            'duration': 30,
+                            'description': 'interim-2021-wgname-02',
+                        },
+                        'url': 'https://meetings.conf.meetecho.com/interim/?short=e68e96d4-d38f-475b-9073-ecab46ca96a5',
+                        'deletion_token': 'session-deletion-token-02',
+                    },
+                }
+            },
+        )
+
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.fetch_meetings(wg_token='my-token')
+
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertIn('Authorization', request.headers)
+        self.assertEqual(request.headers['Authorization'], 'bearer my-token',
+                         'Incorrect request authorization header')
+        self.assertEqual(
+            api_response,
+            {
+                'rooms': {
+                    '3d55bce0-535e-4ba8-bb8e-734911cf3c32': {
+                        'room': {
+                            'id': 18,
+                            'start_time': datetime.datetime(2021, 9, 14, 10, 0, 0),
+                            'duration': datetime.timedelta(minutes=130),
+                            'description': 'interim-2021-wgname-01',
+                        },
+                        'url': 'https://meetings.conf.meetecho.com/interim/?short=3d55bce0-535e-4ba8-bb8e-734911cf3c32',
+                        'deletion_token': 'session-deletion-token-01',
+                    },
+                    'e68e96d4-d38f-475b-9073-ecab46ca96a5': {
+                        'room': {
+                            'id': 23,
+                            'start_time': datetime.datetime(2021, 9, 15, 14, 30, 0),
+                            'duration': datetime.timedelta(minutes=30),
+                            'description': 'interim-2021-wgname-02',
+                        },
+                        'url': 'https://meetings.conf.meetecho.com/interim/?short=e68e96d4-d38f-475b-9073-ecab46ca96a5',
+                        'deletion_token': 'session-deletion-token-02',
+                    },
+                }
+            },
+        )
+
+    def test_delete_meeting(self):
+        data_to_fetch = {}
+        self.requests_mock.post(self.delete_meetings_url, status_code=200, json=data_to_fetch)
+
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.delete_meeting(deletion_token='delete-this-meeting-please')
+
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertIn('Authorization', request.headers)
+        self.assertEqual(request.headers['Authorization'], 'bearer delete-this-meeting-please',
+                         'Incorrect request authorization header')
+        self.assertIsNone(request.body, 'Delete meeting request has no body')
+        self.assertCountEqual(api_response, data_to_fetch)
+
+    def test_request_helper_failed_requests(self):
+        self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'unauthorized/url/endpoint'), status_code=403)
+        self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'notfound/url/endpoint'), status_code=404)
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        for method in ['POST', 'GET']:
+            for code, endpoint in ((403, 'unauthorized/url/endpoint'), (404, 'notfound/url/endpoint')):
+                with self.assertRaises(Exception) as context:
+                    api._request(method, endpoint)
+                self.assertIsInstance(context.exception, MeetechoAPIError)
+                self.assertIn(str(code), str(context.exception))
+
+    def test_request_helper_exception(self):
+        self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'exception/url/endpoint'), exc=requests.exceptions.RequestException)
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        for method in ['POST', 'GET']:
+            with self.assertRaises(Exception) as context:
+                api._request(method, 'exception/url/endpoint')
+            self.assertIsInstance(context.exception, MeetechoAPIError)
+
+    def test_time_serialization(self):
+        """Time de/serialization should be consistent"""
+        time = datetime.datetime.now().replace(microsecond=0)  # cut off to 0 microseconds
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        self.assertEqual(api._deserialize_time(api._serialize_time(time)), time)


### PR DESCRIPTION
This addresses [ticket 3507](https://trac.ietf.org/trac/ietfdb/ticket/3507)

This adds code to use the Meetecho interim REST API to create Meetecho "conferences" (referred to as rooms or sessions on the Meetecho side) when interim sessions are requested. The URL for a session so created is stored in the `remote_instructions` field of the `Session` instance.

Adds a rudimentary management command to list Meetecho conferences for a group or to delete the conference referred to by a session. Meetecho provides already a web interface that can be used for more general management of conferences, so this command is chiefly a convenience for debugging.