### PR TITLE
Delete Meetecho conference matching the remote_instructions of a session being canceled

### DIFF
--- a/ietf/meeting/forms.py
+++ b/ietf/meeting/forms.py
@@ -259,9 +259,9 @@ class InterimSessionModelForm(forms.ModelForm):
         return duration
 
     def clean(self):
-        if not (self.cleaned_data.get('remote_participation', None) == 'meetecho'
-                or self.cleaned_data['remote_instructions']
-        ):
+        if self.cleaned_data.get('remote_participation', None) == 'meetecho':
+            self.cleaned_data['remote_instructions'] = ''  # blank this out if we're creating a Meetecho conference
+        elif not self.cleaned_data['remote_instructions']:
             self.add_error('remote_instructions', 'This field is required')
         return self.cleaned_data
 

--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -1104,6 +1104,17 @@ def sessions_post_save(request, forms):
             )
 
 
+def delete_interim_session_conference(session):
+    """Delete Meetecho conference for the session, if any"""
+    if session.remote_instructions:
+        meetecho_manager = meetecho.ConferenceManager(settings.MEETECHO_API_CONFIG)
+        for conference in meetecho_manager.fetch(session.group):
+            if conference.url == session.remote_instructions:
+                conference.delete()
+                return conference
+    return None
+
+
 def update_interim_session_assignment(form):
     """Helper function to create / update timeslot assigned to interim session"""
     time = datetime.datetime.combine(

--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -1120,6 +1120,11 @@ def delete_interim_session_conferences(sessions):
 
 
 def sessions_post_cancel(request, sessions):
+    """Clean up after session cancellation
+
+    When this is called, the session has already been canceled, so exceptions should
+    not be raised.
+    """
     try:
         delete_interim_session_conferences(sessions)
     except Exception as err:

--- a/ietf/meeting/tests_helpers.py
+++ b/ietf/meeting/tests_helpers.py
@@ -1,6 +1,6 @@
 # Copyright The IETF Trust 2020, All Rights Reserved
 # -*- coding: utf-8 -*-
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from django.conf import settings
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -10,8 +10,9 @@ from ietf.group.factories import GroupFactory
 from ietf.group.models import Group
 from ietf.meeting.factories import SessionFactory, MeetingFactory, TimeSlotFactory
 from ietf.meeting.helpers import (AgendaFilterOrganizer, AgendaKeywordTagger,
-    delete_interim_session_conferences, sessions_post_save, sessions_post_cancel)
-from ietf.meeting.models import SchedTimeSessAssignment
+    delete_interim_session_conferences, sessions_post_save, sessions_post_cancel,
+    create_interim_session_conferences)
+from ietf.meeting.models import SchedTimeSessAssignment, Session
 from ietf.meeting.test_data import make_meeting_test_data
 from ietf.utils.meetecho import Conference
 from ietf.utils.test_utils import TestCase
@@ -347,7 +348,7 @@ class AgendaFilterOrganizerTests(TestCase):
         'request_timeout': 3.01,
     }
 )
-class InterimHelperTests(TestCase):
+class InterimTests(TestCase):
     @patch('ietf.utils.meetecho.ConferenceManager')
     def test_delete_interim_session_conferences(self, mock):
         mock_conf_mgr = mock.return_value  # "instance" seen by the internals
@@ -371,7 +372,14 @@ class InterimHelperTests(TestCase):
             ),
         ]
 
+        # should not call the API if MEETECHO_API_CONFIG is not defined
+        with override_settings():  # will undo any changes to settings in the block
+            del settings.MEETECHO_API_CONFIG
+            delete_interim_session_conferences([sessions[0], sessions[1]])
+        self.assertFalse(mock.called)
+
         # no conferences, no sessions being deleted -> no conferences deleted
+        mock.reset_mock()
         mock_conf_mgr.fetch.return_value = []
         delete_interim_session_conferences([])
         self.assertFalse(mock_conf_mgr.delete_conference.called)
@@ -389,8 +397,8 @@ class InterimHelperTests(TestCase):
         self.assertFalse(mock_conf_mgr.delete_conference.called)
 
         # one conference, same session being deleted -> conference deleted
+        mock.reset_mock()
         mock_conf_mgr.fetch.return_value = [conferences[0]]
-        mock_conf_mgr.delete_conference.reset_mock()
         delete_interim_session_conferences([sessions[0]])
         self.assertTrue(mock_conf_mgr.delete_conference.called)
         self.assertCountEqual(
@@ -399,8 +407,8 @@ class InterimHelperTests(TestCase):
         )
 
         # two conferences, one being deleted -> correct conference deleted
+        mock.reset_mock()
         mock_conf_mgr.fetch.return_value = [conferences[0], conferences[1]]
-        mock_conf_mgr.delete_conference.reset_mock()
         delete_interim_session_conferences([sessions[1]])
         self.assertTrue(mock_conf_mgr.delete_conference.called)
         self.assertEqual(mock_conf_mgr.delete_conference.call_count, 1)
@@ -410,8 +418,8 @@ class InterimHelperTests(TestCase):
         )
 
         # two conferences, both being deleted -> both conferences deleted
+        mock.reset_mock()
         mock_conf_mgr.fetch.return_value = [conferences[0], conferences[1]]
-        mock_conf_mgr.delete_conference.reset_mock()
         delete_interim_session_conferences([sessions[0], sessions[1]])
         self.assertTrue(mock_conf_mgr.delete_conference.called)
         self.assertEqual(mock_conf_mgr.delete_conference.call_count, 2)
@@ -420,18 +428,6 @@ class InterimHelperTests(TestCase):
             args_list,
             ((conferences[0],), (conferences[1],)),
         )
-
-        # should not call the API if MEETECHO_API_CONFIG is not defined
-        with override_settings():
-            del settings.MEETECHO_API_CONFIG
-            mock.reset_mock()
-            mock_conf_mgr.fetch.reset_mock()
-            mock_conf_mgr.fetch.return_value = [conferences[0], conferences[1]]
-            mock_conf_mgr.delete_conference.reset_mock()
-            delete_interim_session_conferences([sessions[0], sessions[1]])
-            self.assertFalse(mock.called)
-            self.assertFalse(mock_conf_mgr.fetch.called)
-            self.assertFalse(mock_conf_mgr.delete_conference.called)
 
     @patch('ietf.meeting.helpers.delete_interim_session_conferences')
     def test_sessions_post_cancel(self, mock):
@@ -444,6 +440,7 @@ class InterimHelperTests(TestCase):
         """sessions_post_cancel prevents exceptions percolating up"""
         mock.side_effect = RuntimeError('oops')
         sessions = SessionFactory.create_batch(3, meeting__type_id='interim')
+        # create mock request with session / message storage
         request = RequestFactory().post('/some/url')
         setattr(request, 'session', 'session')
         messages = FallbackStorage(request)
@@ -451,6 +448,170 @@ class InterimHelperTests(TestCase):
         sessions_post_cancel(request, sessions)
         self.assertTrue(mock.called)
         self.assertEqual(mock.call_args[0], (sessions,))
+        msgs = [str(msg) for msg in messages]
+        self.assertEqual(len(msgs), 1)
+        self.assertIn('An error occurred', msgs[0])
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_create_interim_session_conferences(self, mock):
+        mock_conf_mgr = mock.return_value  # "instance" seen by the internals
+        sessions = [
+            SessionFactory(meeting__type_id='interim', remote_instructions='junk'),
+            SessionFactory(meeting__type_id='interim', remote_instructions=''),
+        ]
+        timeslots = [
+            session.official_timeslotassignment().timeslot for session in sessions
+        ]
+
+        with override_settings():  # will undo any changes to settings in the block
+            del settings.MEETECHO_API_CONFIG
+            create_interim_session_conferences([sessions[0], sessions[1]])
+        self.assertFalse(mock.called)
+
+        # create for 0 sessions
+        mock.reset_mock()
+        create_interim_session_conferences([])
+        self.assertFalse(mock_conf_mgr.create.called)
+        self.assertEqual(
+            Session.objects.get(pk=sessions[0].pk).remote_instructions,
+            'junk',
+        )
+
+        # create for 1 session
+        mock.reset_mock()
+        mock_conf_mgr.create.return_value = [
+            Conference(
+                manager=mock_conf_mgr, id=1, public_id='some-uuid', description='desc',
+                start_time=timeslots[0].time, duration=timeslots[0].duration, url='fake-meetecho-url',
+                deletion_token='please-delete-me',
+            ),
+        ]
+        create_interim_session_conferences([sessions[0]])
+        self.assertTrue(mock_conf_mgr.create.called)
+        self.assertCountEqual(
+            mock_conf_mgr.create.call_args[1],
+            {
+                'group': sessions[0].group,
+                'description': str(sessions[0]),
+                'start_time': timeslots[0].time,
+                'duration': timeslots[0].duration,
+            }
+        )
+        self.assertEqual(
+            Session.objects.get(pk=sessions[0].pk).remote_instructions,
+            'fake-meetecho-url',
+        )
+
+        # create for 2 sessions
+        mock.reset_mock()
+        mock_conf_mgr.create.side_effect = [
+            [Conference(
+                manager=mock_conf_mgr, id=1, public_id='some-uuid', description='desc',
+                start_time=timeslots[0].time, duration=timeslots[0].duration, url='different-fake-meetecho-url',
+                deletion_token='please-delete-me',
+            )],
+            [Conference(
+                manager=mock_conf_mgr, id=2, public_id='another-uuid', description='desc',
+                start_time=timeslots[1].time, duration=timeslots[1].duration, url='another-fake-meetecho-url',
+                deletion_token='please-delete-me-too',
+            )],
+        ]
+        create_interim_session_conferences([sessions[0], sessions[1]])
+        self.assertTrue(mock_conf_mgr.create.called)
+        self.assertCountEqual(
+            mock_conf_mgr.create.call_args_list,
+            [
+                ({
+                    'group': sessions[0].group,
+                    'description': str(sessions[0]),
+                    'start_time': timeslots[0].time,
+                    'duration': timeslots[0].duration,
+                 },),
+                ({
+                    'group': sessions[1].group,
+                    'description': str(sessions[1]),
+                    'start_time': timeslots[1].time,
+                    'duration': timeslots[1].duration,
+                 },),
+            ]
+        )
+        self.assertEqual(
+            Session.objects.get(pk=sessions[0].pk).remote_instructions,
+            'different-fake-meetecho-url',
+        )
+        self.assertEqual(
+            Session.objects.get(pk=sessions[1].pk).remote_instructions,
+            'another-fake-meetecho-url',
+        )
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_create_interim_session_conferences_errors(self, mock):
+        mock_conf_mgr = mock.return_value
+        session = SessionFactory(meeting__type_id='interim')
+        timeslot = session.official_timeslotassignment().timeslot
+
+        mock_conf_mgr.create.return_value = []
+        with self.assertRaises(RuntimeError):
+            create_interim_session_conferences([session])
+
+        mock.reset_mock()
+        mock_conf_mgr.create.return_value = [
+            Conference(
+                manager=mock_conf_mgr, id=1, public_id='some-uuid', description='desc',
+                start_time=timeslot.time, duration=timeslot.duration, url='different-fake-meetecho-url',
+                deletion_token='please-delete-me',
+            ),
+            Conference(
+                manager=mock_conf_mgr, id=2, public_id='another-uuid', description='desc',
+                start_time=timeslot.time, duration=timeslot.duration, url='another-fake-meetecho-url',
+                deletion_token='please-delete-me-too',
+            ),
+        ]
+        with self.assertRaises(RuntimeError):
+            create_interim_session_conferences([session])
+
+        mock.reset_mock()
+        mock_conf_mgr.create.side_effect = ValueError('some error')
+        with self.assertRaises(RuntimeError):
+            create_interim_session_conferences([session])
+
+    @patch('ietf.meeting.helpers.create_interim_session_conferences')
+    def test_sessions_post_save_creates_meetecho_conferences(self, mock_create_method):
+        session = SessionFactory(meeting__type_id='interim')
+        mock_form = Mock()
+        mock_form.instance = session
+        mock_form.has_changed.return_value = True
+        mock_form.changed_data = []
+        mock_form.requires_approval = True
+
+        mock_form.cleaned_data = {'remote_participation': None}
+        sessions_post_save(RequestFactory().post('/some/url'), [mock_form])
+        self.assertTrue(mock_create_method.called)
+        self.assertCountEqual(mock_create_method.call_args[0][0], [])
+
+        mock_create_method.reset_mock()
+        mock_form.cleaned_data = {'remote_participation': 'manual'}
+        sessions_post_save(RequestFactory().post('/some/url'), [mock_form])
+        self.assertTrue(mock_create_method.called)
+        self.assertCountEqual(mock_create_method.call_args[0][0], [])
+
+        mock_create_method.reset_mock()
+        mock_form.cleaned_data = {'remote_participation': 'meetecho'}
+        sessions_post_save(RequestFactory().post('/some/url'), [mock_form])
+        self.assertTrue(mock_create_method.called)
+        self.assertCountEqual(mock_create_method.call_args[0][0], [session])
+
+        # Check that an exception does not percolate through sessions_post_save
+        mock_create_method.side_effect = RuntimeError('some error')
+        mock_form.cleaned_data = {'remote_participation': 'meetecho'}
+        # create mock request with session / message storage
+        request = RequestFactory().post('/some/url')
+        setattr(request, 'session', 'session')
+        messages = FallbackStorage(request)
+        setattr(request, '_messages', messages)
+        sessions_post_save(request, [mock_form])
+        self.assertTrue(mock_create_method.called)
+        self.assertCountEqual(mock_create_method.call_args[0][0], [session])
         msgs = [str(msg) for msg in messages]
         self.assertEqual(len(msgs), 1)
         self.assertIn('An error occurred', msgs[0])

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -5243,8 +5243,32 @@ class InterimTests(TestCase):
 
         url = urlreverse('ietf.meeting.views.interim_request_cancel', kwargs={'number': meeting.number})
         self.client.login(username="marschairman", password="marschairman+password")
-        r = self.client.post(url)
+        self.client.post(url)
         self.assertEqual(mock_delete_conference.call_args[0], (the_conference,))
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_cancel_meetecho_handles_error(self, mock_conf_mgr):
+        """Can cancel an interim request even if Meetecho calls fail"""
+        make_interim_test_data()
+        meeting = Session.objects.with_current_status(
+        ).filter(
+            meeting__type='interim',
+            group__acronym='mars',
+            current_status='apprw',
+        ).first().meeting
+
+        # set up the ConferenceManager mock to yield a conference matching the interim
+        session = meeting.session_set.first()
+        session.remote_instructions = 'fake-meetecho-url'
+        session.save()
+        mock_fetch = mock_conf_mgr.return_value.fetch
+        mock_fetch.side_effect = RuntimeError('some error')
+        url = urlreverse('ietf.meeting.views.interim_request_cancel', kwargs={'number': meeting.number})
+        self.client.login(username="marschairman", password="marschairman+password")
+        r = self.client.post(url)
+        self.assertRedirects(r, urlreverse('ietf.meeting.views.upcoming'))
+        for session in meeting.session_set.with_current_status():
+            self.assertEqual(session.current_status,'canceledpa')
 
     def test_interim_request_session_cancel(self):
         """Test that interim meeting session cancellation functions
@@ -5357,9 +5381,60 @@ class InterimTests(TestCase):
 
         url = urlreverse('ietf.meeting.views.interim_request_cancel', kwargs={'number': meeting.number})
         self.client.login(username="marschairman", password="marschairman+password")
-        r = self.client.post(url)
+        self.client.post(url)
         self.assertEqual(mock_delete_conference.call_count, 1)
         self.assertEqual(mock_delete_conference.call_args[0], (the_conference,))
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_session_cancel_meetecho_handles_error(self, mock_conf_mgr):
+        make_interim_test_data()
+        meeting = Session.objects.with_current_status(
+        ).filter(
+            meeting__type='interim',
+            group__acronym='mars',
+            current_status='apprw',
+        ).first().meeting
+
+        # set up the ConferenceManager mock to yield a conference matching the first interim session
+        session = meeting.session_set.first()
+        ts = session.official_timeslotassignment().timeslot
+        session.remote_instructions = 'fake-meetecho-url'
+        session.save()
+        # Add a second session
+        SessionFactory(meeting=meeting, status_id='apprw', remote_instructions='another-fake-meetecho-url')
+
+        mock_fetch = mock_conf_mgr.return_value.fetch
+        the_conference = Conference(
+            manager=mock_conf_mgr.return_value, id=1, public_id='some-uuid', description='desc',
+            start_time=ts.time, duration = ts.duration, url='fake-meetecho-url',
+            deletion_token='please-delete-me',
+        )
+        other_conference = Conference(
+            manager=mock_conf_mgr.return_value, id=2, public_id='some-uuid-2', description='desc',
+            start_time=ts.time, duration = ts.duration, url='other-fake-meetecho-url',
+            deletion_token='please-delete-me-as-well',
+        )
+        mock_fetch.return_value = [the_conference, other_conference]
+        mock_delete_conference = mock_conf_mgr.return_value.delete_conference
+        mock_delete_conference.side_effect = RuntimeError('some error')
+
+        canceled_count_before = meeting.session_set.with_current_status().filter(
+            current_status__in=['canceled', 'canceledpa']).count()
+        url = urlreverse('ietf.meeting.views.interim_request_cancel', kwargs={'number': meeting.number})
+        self.client.login(username="marschairman", password="marschairman+password")
+        r = self.client.post(url)
+        self.assertRedirects(r, urlreverse('ietf.meeting.views.interim_request_details',
+                                           kwargs={'number': meeting.number}))
+        # This session should be canceled...
+        sessions = meeting.session_set.with_current_status()
+        session = sessions.filter(id=session.pk).first()  # reload our session info
+        self.assertEqual(session.current_status, 'canceled')
+        self.assertEqual(session.agenda_note)
+        # But others should not - count should have changed by only 1
+        self.assertEqual(
+            sessions.filter(current_status__in=['canceled', 'canceledpa']).count(),
+            canceled_count_before + 1
+        )
 
     def test_interim_request_edit_no_notice(self):
         '''Edit a request.  No notice should go out if it hasn't been announced yet'''

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -4699,7 +4699,7 @@ class InterimTests(TestCase):
         mock_create = mock_conf_mgr.return_value.create
         mock_create.side_effect = [
             [Conference(
-                mock_conf_mgr,
+                mock_conf_mgr.return_value,
                 id=1,
                 public_id='this-is-a-uuid',
                 description='the-description',
@@ -4709,7 +4709,7 @@ class InterimTests(TestCase):
                 deletion_token='delete-me',
             )],
             [Conference(
-                mock_conf_mgr,
+                mock_conf_mgr.return_value,
                 id=2,
                 public_id='this-is-another-uuid',
                 description='the-description',
@@ -5217,6 +5217,35 @@ class InterimTests(TestCase):
         self.assertEqual(len(outbox), length_before + 1)
         self.assertIn('Interim Meeting Cancelled', outbox[-1]['Subject'])
 
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_cancel_meetecho(self, mock_conf_mgr):
+        make_interim_test_data()
+        meeting = Session.objects.with_current_status(
+        ).filter(
+            meeting__type='interim',
+            group__acronym='mars',
+            current_status='apprw',
+        ).first().meeting
+
+        # set up the ConferenceManager mock to yield a conference matching the interim
+        session = meeting.session_set.first()
+        ts = session.official_timeslotassignment().timeslot
+        session.remote_instructions = 'fake-meetecho-url'
+        session.save()
+        mock_fetch = mock_conf_mgr.return_value.fetch
+        the_conference = Conference(
+            manager=mock_conf_mgr.return_value, id=1, public_id='some-uuid', description='desc',
+            start_time=ts.time, duration = ts.duration, url='fake-meetecho-url',
+            deletion_token='please-delete-me',
+        )
+        mock_fetch.return_value = [the_conference]
+        mock_delete_conference = mock_conf_mgr.return_value.delete_conference
+
+        url = urlreverse('ietf.meeting.views.interim_request_cancel', kwargs={'number': meeting.number})
+        self.client.login(username="marschairman", password="marschairman+password")
+        r = self.client.post(url)
+        self.assertEqual(mock_delete_conference.call_args[0], (the_conference,))
+
     def test_interim_request_session_cancel(self):
         """Test that interim meeting session cancellation functions
 
@@ -5293,6 +5322,44 @@ class InterimTests(TestCase):
         )
         self.assertEqual(len(outbox), length_before + 1)     # email notice sent
         self.assertIn('session cancelled', outbox[-1]['Subject'])
+
+    @patch('ietf.utils.meetecho.ConferenceManager')
+    def test_interim_request_session_cancel_meetecho(self, mock_conf_mgr):
+        make_interim_test_data()
+        meeting = Session.objects.with_current_status(
+        ).filter(
+            meeting__type='interim',
+            group__acronym='mars',
+            current_status='apprw',
+        ).first().meeting
+
+        # set up the ConferenceManager mock to yield a conference matching the first interim session
+        session = meeting.session_set.first()
+        ts = session.official_timeslotassignment().timeslot
+        session.remote_instructions = 'fake-meetecho-url'
+        session.save()
+        # Add a second session
+        SessionFactory(meeting=meeting, status_id='apprw', remote_instructions='another-fake-meetecho-url')
+
+        mock_fetch = mock_conf_mgr.return_value.fetch
+        the_conference = Conference(
+            manager=mock_conf_mgr.return_value, id=1, public_id='some-uuid', description='desc',
+            start_time=ts.time, duration = ts.duration, url='fake-meetecho-url',
+            deletion_token='please-delete-me',
+        )
+        other_conference = Conference(
+            manager=mock_conf_mgr.return_value, id=2, public_id='some-uuid-2', description='desc',
+            start_time=ts.time, duration = ts.duration, url='other-fake-meetecho-url',
+            deletion_token='please-delete-me-as-well',
+        )
+        mock_fetch.return_value = [the_conference, other_conference]
+        mock_delete_conference = mock_conf_mgr.return_value.delete_conference
+
+        url = urlreverse('ietf.meeting.views.interim_request_cancel', kwargs={'number': meeting.number})
+        self.client.login(username="marschairman", password="marschairman+password")
+        r = self.client.post(url)
+        self.assertEqual(mock_delete_conference.call_count, 1)
+        self.assertEqual(mock_delete_conference.call_args[0], (the_conference,))
 
     def test_interim_request_edit_no_notice(self):
         '''Edit a request.  No notice should go out if it hasn't been announced yet'''

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -71,7 +71,7 @@ from ietf.meeting.helpers import sessions_post_save, is_interim_meeting_approved
 from ietf.meeting.helpers import send_interim_meeting_cancellation_notice, send_interim_session_cancellation_notice
 from ietf.meeting.helpers import send_interim_approval
 from ietf.meeting.helpers import send_interim_approval_request
-from ietf.meeting.helpers import send_interim_announcement_request, delete_interim_session_conference
+from ietf.meeting.helpers import send_interim_announcement_request, sessions_post_cancel
 from ietf.meeting.utils import finalize, sort_accept_tuple, condition_slide_order
 from ietf.meeting.utils import add_event_info_to_session_qs
 from ietf.meeting.utils import session_time_for_sorting
@@ -3184,8 +3184,9 @@ def interim_request_cancel(request, number):
             was_scheduled = session_status.slug == 'sched'
 
             result_status = SessionStatusName.objects.get(slug='canceled' if was_scheduled else 'canceledpa')
-            for session in meeting.session_set.not_canceled():
-                delete_interim_session_conference(session)
+            sessions_to_cancel = meeting.session_set.not_canceled()
+            for session in sessions_to_cancel:
+
                 SchedulingEvent.objects.create(
                     session=session,
                     status=result_status,
@@ -3194,6 +3195,8 @@ def interim_request_cancel(request, number):
 
             if was_scheduled:
                 send_interim_meeting_cancellation_notice(meeting)
+
+            sessions_post_cancel(request, sessions_to_cancel)
 
             messages.success(request, 'Interim meeting cancelled')
             return redirect(upcoming)
@@ -3232,7 +3235,6 @@ def interim_request_session_cancel(request, sessionid):
 
             was_scheduled = session_status.slug == 'sched'
 
-            delete_interim_session_conference(session)
             result_status = SessionStatusName.objects.get(slug='canceled' if was_scheduled else 'canceledpa')
             SchedulingEvent.objects.create(
                 session=session,
@@ -3242,6 +3244,8 @@ def interim_request_session_cancel(request, sessionid):
 
             if was_scheduled:
                 send_interim_session_cancellation_notice(session)
+
+            sessions_post_cancel(request, [session])
 
             messages.success(request, 'Interim meeting session cancelled')
             return redirect(interim_request_details, number=session.meeting.number)

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -71,7 +71,7 @@ from ietf.meeting.helpers import sessions_post_save, is_interim_meeting_approved
 from ietf.meeting.helpers import send_interim_meeting_cancellation_notice, send_interim_session_cancellation_notice
 from ietf.meeting.helpers import send_interim_approval
 from ietf.meeting.helpers import send_interim_approval_request
-from ietf.meeting.helpers import send_interim_announcement_request
+from ietf.meeting.helpers import send_interim_announcement_request, delete_interim_session_conference
 from ietf.meeting.utils import finalize, sort_accept_tuple, condition_slide_order
 from ietf.meeting.utils import add_event_info_to_session_qs
 from ietf.meeting.utils import session_time_for_sorting
@@ -3185,6 +3185,7 @@ def interim_request_cancel(request, number):
 
             result_status = SessionStatusName.objects.get(slug='canceled' if was_scheduled else 'canceledpa')
             for session in meeting.session_set.not_canceled():
+                delete_interim_session_conference(session)
                 SchedulingEvent.objects.create(
                     session=session,
                     status=result_status,
@@ -3231,6 +3232,7 @@ def interim_request_session_cancel(request, sessionid):
 
             was_scheduled = session_status.slug == 'sched'
 
+            delete_interim_session_conference(session)
             result_status = SessionStatusName.objects.get(slug='canceled' if was_scheduled else 'canceledpa')
             SchedulingEvent.objects.create(
                 session=session,

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1241,7 +1241,8 @@ DEFAULT_REQUESTS_TIMEOUT = 20  # seconds
 MEETECHO_API_CONFIG = {
     'api_base': 'https://meetings.conf.meetecho.com/api/v1/',
     'client_id': 'datatracker',
-    'client_secret': 'some secreat',
+    'client_secret': 'some secret',
+    'request_timeout': 3.01,  # python-requests doc recommend slightly > a multiple of 3 seconds
 }
 
 

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -15,7 +15,7 @@ import debug  # pyflakes: ignore
 
 from datetime import datetime, timedelta
 from json import JSONDecodeError
-from typing import List, Sequence, Type, TypeVar, Union
+from typing import Dict, Sequence, Union
 from urllib.parse import urljoin
 
 
@@ -175,8 +175,6 @@ class MeetechoAPIError(Exception):
     """Base class for MeetechoAPI exceptions"""
 
 
-_T = TypeVar('_T')
-
 class Conference:
     """Scheduled session/room representation"""
     def __init__(self, manager, id, public_id, description, start_time, duration, url, deletion_token):
@@ -190,7 +188,8 @@ class Conference:
         self.deletion_token = deletion_token
 
     @classmethod
-    def from_api_dict(cls: Type[_T], manager, api_dict) -> List[_T]:
+    def from_api_dict(cls, manager, api_dict):
+        # Returns a list of Conferences
         return [
             cls(
                 **val['room'],
@@ -228,7 +227,7 @@ class Conference:
 class ConferenceManager:
     def __init__(self, api_config: dict):
         self.api = MeetechoAPI(**api_config)
-        self.wg_tokens = {}
+        self.wg_tokens: Dict[str, str] = {}
         
     def wg_token(self, group):
         group_acronym = group.acronym if hasattr(group, 'acronym') else group

--- a/ietf/utils/tests_meetecho.py
+++ b/ietf/utils/tests_meetecho.py
@@ -231,11 +231,12 @@ class APITests(TestCase):
         self.assertCountEqual(api_response, data_to_fetch)
 
     def test_request_helper_failed_requests(self):
-        self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'unauthorized/url/endpoint'), status_code=403)
+        self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'unauthorized/url/endpoint'), status_code=401)
+        self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'forbidden/url/endpoint'), status_code=403)
         self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'notfound/url/endpoint'), status_code=404)
         api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
         for method in ['POST', 'GET']:
-            for code, endpoint in ((403, 'unauthorized/url/endpoint'), (404, 'notfound/url/endpoint')):
+            for code, endpoint in ((401, 'unauthorized/url/endpoint'), (403, 'forbidden/url/endpoint'), (404, 'notfound/url/endpoint')):
                 with self.assertRaises(Exception) as context:
                     api._request(method, endpoint)
                 self.assertIsInstance(context.exception, MeetechoAPIError)


### PR DESCRIPTION
Addresses [ticket 3508](https://trac.ietf.org/trac/ietfdb/ticket/3508#ticket)

  * Delete Meetecho conference when canceling an interim meeting or session
  * Test that the expected conferences are deleted through the API
  * Adjust mocks for previous Meetecho creation tests (does not affect test behavior)